### PR TITLE
Fix: scope validation issue for certain routes

### DIFF
--- a/pkg/gateway/routes.go
+++ b/pkg/gateway/routes.go
@@ -59,6 +59,7 @@ func populateRoutes(routes *route.RouteTable) {
 				isPublic:       utils.PBool(r.IsPublic),
 				isRoot:         utils.PBool(r.IsRoot),
 				isUserSpecific: utils.PBool(r.IsUserSpecific),
+				scopes:         r.Scopes,
 			}
 		}
 	}


### PR DESCRIPTION
when same url prefix combination exists with multiple http methods, routes addition to after the first one misses out on setting the scopes information as part of the patricia tree entries, causing failure of scope check while performing roles match on org unit level

Ensure populating the same as part of the node information