### PR TITLE
Refactor admin role check to use slices.Contains

### DIFF
--- a/pkg/gateway/server.go
+++ b/pkg/gateway/server.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
+	"slices"
 	"sync"
 	"time"
 
@@ -249,13 +250,7 @@ func (s *gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			// perform RBAC / PBAC and scope validations
 			// TODO(prabhjot) currently only allow admin role
-			isTenantAdmin := false
-			for _, role := range authInfo.Roles {
-				if role == "admin" {
-					isTenantAdmin = true
-					break
-				}
-			}
+			isTenantAdmin := slices.Contains(authInfo.Roles, "admin")
 
 			if !isTenantAdmin {
 				allow := false


### PR DESCRIPTION
Replace manual loop iteration with slices.Contains for checking admin role in authInfo.Roles slice. This improves code readability and leverages Go's standard library utility function.

The change maintains the same functionality while making the code more concise and idiomatic Go style.