### PR TITLE
Feat: Add User Session Configuration management feature

### DIFF
--- a/api/mytenant.pb.go
+++ b/api/mytenant.pb.go
@@ -26,6 +26,55 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// behavior when session limit is exceeded
+type SessionLimitBehavior int32
+
+const (
+	// deny new session (reject login)
+	SessionLimitBehavior_DENY SessionLimitBehavior = 0
+	// terminate oldest session to allow new login
+	SessionLimitBehavior_TERMINATE SessionLimitBehavior = 1
+)
+
+// Enum value maps for SessionLimitBehavior.
+var (
+	SessionLimitBehavior_name = map[int32]string{
+		0: "DENY",
+		1: "TERMINATE",
+	}
+	SessionLimitBehavior_value = map[string]int32{
+		"DENY":      0,
+		"TERMINATE": 1,
+	}
+)
+
+func (x SessionLimitBehavior) Enum() *SessionLimitBehavior {
+	p := new(SessionLimitBehavior)
+	*p = x
+	return p
+}
+
+func (x SessionLimitBehavior) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SessionLimitBehavior) Descriptor() protoreflect.EnumDescriptor {
+	return file_mytenant_proto_enumTypes[0].Descriptor()
+}
+
+func (SessionLimitBehavior) Type() protoreflect.EnumType {
+	return &file_mytenant_proto_enumTypes[0]
+}
+
+func (x SessionLimitBehavior) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SessionLimitBehavior.Descriptor instead.
+func (SessionLimitBehavior) EnumDescriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{0}
+}
+
 // password policy get request
 type MyPasswordPolicyGetReq struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -336,6 +385,263 @@ func (*MyPasswordPolicyUpdateResp) Descriptor() ([]byte, []int) {
 	return file_mytenant_proto_rawDescGZIP(), []int{3}
 }
 
+// Keycloak session limits configuration
+type KeycloakSessionLimitsConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// maximum number of concurrent sessions per user
+	MaxConcurrentSessions int32 `protobuf:"varint,1,opt,name=max_concurrent_sessions,json=maxConcurrentSessions,proto3" json:"max_concurrent_sessions,omitempty"`
+	// behavior when limit is exceeded
+	BehaviorWhenLimitExceeded SessionLimitBehavior `protobuf:"varint,2,opt,name=behavior_when_limit_exceeded,json=behaviorWhenLimitExceeded,proto3,enum=api.SessionLimitBehavior" json:"behavior_when_limit_exceeded,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *KeycloakSessionLimitsConfig) Reset() {
+	*x = KeycloakSessionLimitsConfig{}
+	mi := &file_mytenant_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *KeycloakSessionLimitsConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KeycloakSessionLimitsConfig) ProtoMessage() {}
+
+func (x *KeycloakSessionLimitsConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use KeycloakSessionLimitsConfig.ProtoReflect.Descriptor instead.
+func (*KeycloakSessionLimitsConfig) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *KeycloakSessionLimitsConfig) GetMaxConcurrentSessions() int32 {
+	if x != nil {
+		return x.MaxConcurrentSessions
+	}
+	return 0
+}
+
+func (x *KeycloakSessionLimitsConfig) GetBehaviorWhenLimitExceeded() SessionLimitBehavior {
+	if x != nil {
+		return x.BehaviorWhenLimitExceeded
+	}
+	return SessionLimitBehavior_DENY
+}
+
+// get Keycloak session limits instructions request
+type GetKeycloakSessionLimitsInstructionsReq struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// optional configuration to generate specific instructions
+	Config        *KeycloakSessionLimitsConfig `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetKeycloakSessionLimitsInstructionsReq) Reset() {
+	*x = GetKeycloakSessionLimitsInstructionsReq{}
+	mi := &file_mytenant_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetKeycloakSessionLimitsInstructionsReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetKeycloakSessionLimitsInstructionsReq) ProtoMessage() {}
+
+func (x *GetKeycloakSessionLimitsInstructionsReq) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetKeycloakSessionLimitsInstructionsReq.ProtoReflect.Descriptor instead.
+func (*GetKeycloakSessionLimitsInstructionsReq) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *GetKeycloakSessionLimitsInstructionsReq) GetConfig() *KeycloakSessionLimitsConfig {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+// get Keycloak session limits instructions response
+type GetKeycloakSessionLimitsInstructionsResp struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// step-by-step instructions for manual configuration
+	Instructions string `protobuf:"bytes,1,opt,name=instructions,proto3" json:"instructions,omitempty"`
+	// current realm name
+	Realm         string `protobuf:"bytes,2,opt,name=realm,proto3" json:"realm,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetKeycloakSessionLimitsInstructionsResp) Reset() {
+	*x = GetKeycloakSessionLimitsInstructionsResp{}
+	mi := &file_mytenant_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetKeycloakSessionLimitsInstructionsResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetKeycloakSessionLimitsInstructionsResp) ProtoMessage() {}
+
+func (x *GetKeycloakSessionLimitsInstructionsResp) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetKeycloakSessionLimitsInstructionsResp.ProtoReflect.Descriptor instead.
+func (*GetKeycloakSessionLimitsInstructionsResp) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *GetKeycloakSessionLimitsInstructionsResp) GetInstructions() string {
+	if x != nil {
+		return x.Instructions
+	}
+	return ""
+}
+
+func (x *GetKeycloakSessionLimitsInstructionsResp) GetRealm() string {
+	if x != nil {
+		return x.Realm
+	}
+	return ""
+}
+
+// configure Keycloak session limits request
+type ConfigureKeycloakSessionLimitsReq struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// session limits configuration
+	Config        *KeycloakSessionLimitsConfig `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConfigureKeycloakSessionLimitsReq) Reset() {
+	*x = ConfigureKeycloakSessionLimitsReq{}
+	mi := &file_mytenant_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigureKeycloakSessionLimitsReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigureKeycloakSessionLimitsReq) ProtoMessage() {}
+
+func (x *ConfigureKeycloakSessionLimitsReq) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigureKeycloakSessionLimitsReq.ProtoReflect.Descriptor instead.
+func (*ConfigureKeycloakSessionLimitsReq) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *ConfigureKeycloakSessionLimitsReq) GetConfig() *KeycloakSessionLimitsConfig {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+// configure Keycloak session limits response
+type ConfigureKeycloakSessionLimitsResp struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// success message
+	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	// manual configuration instructions
+	Instructions  string `protobuf:"bytes,2,opt,name=instructions,proto3" json:"instructions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConfigureKeycloakSessionLimitsResp) Reset() {
+	*x = ConfigureKeycloakSessionLimitsResp{}
+	mi := &file_mytenant_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigureKeycloakSessionLimitsResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigureKeycloakSessionLimitsResp) ProtoMessage() {}
+
+func (x *ConfigureKeycloakSessionLimitsResp) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigureKeycloakSessionLimitsResp.ProtoReflect.Descriptor instead.
+func (*ConfigureKeycloakSessionLimitsResp) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ConfigureKeycloakSessionLimitsResp) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *ConfigureKeycloakSessionLimitsResp) GetInstructions() string {
+	if x != nil {
+		return x.Instructions
+	}
+	return ""
+}
+
 var File_mytenant_proto protoreflect.FileDescriptor
 
 const file_mytenant_proto_rawDesc = "" +
@@ -366,12 +672,32 @@ const file_mytenant_proto_rawDesc = "" +
 	"\frecentlyUsed\x18\a \x01(\x05R\frecentlyUsed\x12 \n" +
 	"\vpasswordAge\x18\b \x01(\x05R\vpasswordAge\x12<\n" +
 	"\x19forceExpirePasswordChange\x18\t \x01(\x05R\x19forceExpirePasswordChange\"\x1c\n" +
-	"\x1aMyPasswordPolicyUpdateResp2\xc7\x02\n" +
+	"\x1aMyPasswordPolicyUpdateResp\"\xb1\x01\n" +
+	"\x1bKeycloakSessionLimitsConfig\x126\n" +
+	"\x17max_concurrent_sessions\x18\x01 \x01(\x05R\x15maxConcurrentSessions\x12Z\n" +
+	"\x1cbehavior_when_limit_exceeded\x18\x02 \x01(\x0e2\x19.api.SessionLimitBehaviorR\x19behaviorWhenLimitExceeded\"c\n" +
+	"'GetKeycloakSessionLimitsInstructionsReq\x128\n" +
+	"\x06config\x18\x01 \x01(\v2 .api.KeycloakSessionLimitsConfigR\x06config\"d\n" +
+	"(GetKeycloakSessionLimitsInstructionsResp\x12\"\n" +
+	"\finstructions\x18\x01 \x01(\tR\finstructions\x12\x14\n" +
+	"\x05realm\x18\x02 \x01(\tR\x05realm\"]\n" +
+	"!ConfigureKeycloakSessionLimitsReq\x128\n" +
+	"\x06config\x18\x01 \x01(\v2 .api.KeycloakSessionLimitsConfigR\x06config\"b\n" +
+	"\"ConfigureKeycloakSessionLimitsResp\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\x12\"\n" +
+	"\finstructions\x18\x02 \x01(\tR\finstructions*/\n" +
+	"\x14SessionLimitBehavior\x12\b\n" +
+	"\x04DENY\x10\x00\x12\r\n" +
+	"\tTERMINATE\x10\x012\xdd\x05\n" +
 	"\bMyTenant\x12\x94\x01\n" +
 	"\x13GetMyPasswordPolicy\x12\x1b.api.MyPasswordPolicyGetReq\x1a\x1c.api.MyPasswordPolicyGetResp\"B\x8a\xb5\x18\x16\n" +
 	"\x0fpassword-policy\x1a\x03get\x82\xd3\xe4\x93\x02\"\x12 /api/mytenant/v1/password-policy\x12\xa3\x01\n" +
 	"\x16UpdateMyPasswordPolicy\x12\x1e.api.MyPasswordPolicyUpdateReq\x1a\x1f.api.MyPasswordPolicyUpdateResp\"H\x8a\xb5\x18\x19\n" +
-	"\x0fpassword-policy\x1a\x06update\x82\xd3\xe4\x93\x02%:\x01*\x1a /api/mytenant/v1/password-policyB+Z)github.com/go-core-stack/auth-gateway/apib\x06proto3"
+	"\x0fpassword-policy\x1a\x06update\x82\xd3\xe4\x93\x02%:\x01*\x1a /api/mytenant/v1/password-policy\x12\xce\x01\n" +
+	"$GetKeycloakSessionLimitsInstructions\x12,.api.GetKeycloakSessionLimitsInstructionsReq\x1a-.api.GetKeycloakSessionLimitsInstructionsResp\"I\x8a\xb5\x18\x15\n" +
+	"\x0esession-limits\x1a\x03get\x82\xd3\xe4\x93\x02*\x12(/api/mytenant/v1/keycloak-session-limits\x12\xc2\x01\n" +
+	"\x1eConfigureKeycloakSessionLimits\x12&.api.ConfigureKeycloakSessionLimitsReq\x1a'.api.ConfigureKeycloakSessionLimitsResp\"O\x8a\xb5\x18\x18\n" +
+	"\x0esession-limits\x1a\x06update\x82\xd3\xe4\x93\x02-:\x01*\x1a(/api/mytenant/v1/keycloak-session-limitsB+Z)github.com/go-core-stack/auth-gateway/apib\x06proto3"
 
 var (
 	file_mytenant_proto_rawDescOnce sync.Once
@@ -385,23 +711,37 @@ func file_mytenant_proto_rawDescGZIP() []byte {
 	return file_mytenant_proto_rawDescData
 }
 
-var file_mytenant_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_mytenant_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_mytenant_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_mytenant_proto_goTypes = []any{
-	(*MyPasswordPolicyGetReq)(nil),     // 0: api.MyPasswordPolicyGetReq
-	(*MyPasswordPolicyGetResp)(nil),    // 1: api.MyPasswordPolicyGetResp
-	(*MyPasswordPolicyUpdateReq)(nil),  // 2: api.MyPasswordPolicyUpdateReq
-	(*MyPasswordPolicyUpdateResp)(nil), // 3: api.MyPasswordPolicyUpdateResp
+	(SessionLimitBehavior)(0),                        // 0: api.SessionLimitBehavior
+	(*MyPasswordPolicyGetReq)(nil),                   // 1: api.MyPasswordPolicyGetReq
+	(*MyPasswordPolicyGetResp)(nil),                  // 2: api.MyPasswordPolicyGetResp
+	(*MyPasswordPolicyUpdateReq)(nil),                // 3: api.MyPasswordPolicyUpdateReq
+	(*MyPasswordPolicyUpdateResp)(nil),               // 4: api.MyPasswordPolicyUpdateResp
+	(*KeycloakSessionLimitsConfig)(nil),              // 5: api.KeycloakSessionLimitsConfig
+	(*GetKeycloakSessionLimitsInstructionsReq)(nil),  // 6: api.GetKeycloakSessionLimitsInstructionsReq
+	(*GetKeycloakSessionLimitsInstructionsResp)(nil), // 7: api.GetKeycloakSessionLimitsInstructionsResp
+	(*ConfigureKeycloakSessionLimitsReq)(nil),        // 8: api.ConfigureKeycloakSessionLimitsReq
+	(*ConfigureKeycloakSessionLimitsResp)(nil),       // 9: api.ConfigureKeycloakSessionLimitsResp
 }
 var file_mytenant_proto_depIdxs = []int32{
-	0, // 0: api.MyTenant.GetMyPasswordPolicy:input_type -> api.MyPasswordPolicyGetReq
-	2, // 1: api.MyTenant.UpdateMyPasswordPolicy:input_type -> api.MyPasswordPolicyUpdateReq
-	1, // 2: api.MyTenant.GetMyPasswordPolicy:output_type -> api.MyPasswordPolicyGetResp
-	3, // 3: api.MyTenant.UpdateMyPasswordPolicy:output_type -> api.MyPasswordPolicyUpdateResp
-	2, // [2:4] is the sub-list for method output_type
-	0, // [0:2] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	0, // 0: api.KeycloakSessionLimitsConfig.behavior_when_limit_exceeded:type_name -> api.SessionLimitBehavior
+	5, // 1: api.GetKeycloakSessionLimitsInstructionsReq.config:type_name -> api.KeycloakSessionLimitsConfig
+	5, // 2: api.ConfigureKeycloakSessionLimitsReq.config:type_name -> api.KeycloakSessionLimitsConfig
+	1, // 3: api.MyTenant.GetMyPasswordPolicy:input_type -> api.MyPasswordPolicyGetReq
+	3, // 4: api.MyTenant.UpdateMyPasswordPolicy:input_type -> api.MyPasswordPolicyUpdateReq
+	6, // 5: api.MyTenant.GetKeycloakSessionLimitsInstructions:input_type -> api.GetKeycloakSessionLimitsInstructionsReq
+	8, // 6: api.MyTenant.ConfigureKeycloakSessionLimits:input_type -> api.ConfigureKeycloakSessionLimitsReq
+	2, // 7: api.MyTenant.GetMyPasswordPolicy:output_type -> api.MyPasswordPolicyGetResp
+	4, // 8: api.MyTenant.UpdateMyPasswordPolicy:output_type -> api.MyPasswordPolicyUpdateResp
+	7, // 9: api.MyTenant.GetKeycloakSessionLimitsInstructions:output_type -> api.GetKeycloakSessionLimitsInstructionsResp
+	9, // 10: api.MyTenant.ConfigureKeycloakSessionLimits:output_type -> api.ConfigureKeycloakSessionLimitsResp
+	7, // [7:11] is the sub-list for method output_type
+	3, // [3:7] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_mytenant_proto_init() }
@@ -414,13 +754,14 @@ func file_mytenant_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_mytenant_proto_rawDesc), len(file_mytenant_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   4,
+			NumEnums:      1,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_mytenant_proto_goTypes,
 		DependencyIndexes: file_mytenant_proto_depIdxs,
+		EnumInfos:         file_mytenant_proto_enumTypes,
 		MessageInfos:      file_mytenant_proto_msgTypes,
 	}.Build()
 	File_mytenant_proto = out.File

--- a/api/mytenant.pb.gw.go
+++ b/api/mytenant.pb.gw.go
@@ -78,6 +78,63 @@ func local_request_MyTenant_UpdateMyPasswordPolicy_0(ctx context.Context, marsha
 	return msg, metadata, err
 }
 
+var filter_MyTenant_GetKeycloakSessionLimitsInstructions_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_MyTenant_GetKeycloakSessionLimitsInstructions_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetKeycloakSessionLimitsInstructionsReq
+		metadata runtime.ServerMetadata
+	)
+	io.Copy(io.Discard, req.Body)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_MyTenant_GetKeycloakSessionLimitsInstructions_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.GetKeycloakSessionLimitsInstructions(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MyTenant_GetKeycloakSessionLimitsInstructions_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetKeycloakSessionLimitsInstructionsReq
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_MyTenant_GetKeycloakSessionLimitsInstructions_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.GetKeycloakSessionLimitsInstructions(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_MyTenant_ConfigureKeycloakSessionLimits_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ConfigureKeycloakSessionLimitsReq
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.ConfigureKeycloakSessionLimits(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MyTenant_ConfigureKeycloakSessionLimits_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ConfigureKeycloakSessionLimitsReq
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ConfigureKeycloakSessionLimits(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterMyTenantHandlerServer registers the http handlers for service MyTenant to "mux".
 // UnaryRPC     :call MyTenantServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -123,6 +180,46 @@ func RegisterMyTenantHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 			return
 		}
 		forward_MyTenant_UpdateMyPasswordPolicy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_MyTenant_GetKeycloakSessionLimitsInstructions_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/GetKeycloakSessionLimitsInstructions", runtime.WithHTTPPathPattern("/api/mytenant/v1/keycloak-session-limits"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MyTenant_GetKeycloakSessionLimitsInstructions_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_GetKeycloakSessionLimitsInstructions_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPut, pattern_MyTenant_ConfigureKeycloakSessionLimits_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/ConfigureKeycloakSessionLimits", runtime.WithHTTPPathPattern("/api/mytenant/v1/keycloak-session-limits"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MyTenant_ConfigureKeycloakSessionLimits_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_ConfigureKeycloakSessionLimits_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -198,15 +295,53 @@ func RegisterMyTenantHandlerClient(ctx context.Context, mux *runtime.ServeMux, c
 		}
 		forward_MyTenant_UpdateMyPasswordPolicy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_MyTenant_GetKeycloakSessionLimitsInstructions_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/GetKeycloakSessionLimitsInstructions", runtime.WithHTTPPathPattern("/api/mytenant/v1/keycloak-session-limits"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MyTenant_GetKeycloakSessionLimitsInstructions_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_GetKeycloakSessionLimitsInstructions_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPut, pattern_MyTenant_ConfigureKeycloakSessionLimits_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/ConfigureKeycloakSessionLimits", runtime.WithHTTPPathPattern("/api/mytenant/v1/keycloak-session-limits"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MyTenant_ConfigureKeycloakSessionLimits_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_ConfigureKeycloakSessionLimits_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_MyTenant_GetMyPasswordPolicy_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "password-policy"}, ""))
-	pattern_MyTenant_UpdateMyPasswordPolicy_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "password-policy"}, ""))
+	pattern_MyTenant_GetMyPasswordPolicy_0                  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "password-policy"}, ""))
+	pattern_MyTenant_UpdateMyPasswordPolicy_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "password-policy"}, ""))
+	pattern_MyTenant_GetKeycloakSessionLimitsInstructions_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "keycloak-session-limits"}, ""))
+	pattern_MyTenant_ConfigureKeycloakSessionLimits_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "keycloak-session-limits"}, ""))
 )
 
 var (
-	forward_MyTenant_GetMyPasswordPolicy_0    = runtime.ForwardResponseMessage
-	forward_MyTenant_UpdateMyPasswordPolicy_0 = runtime.ForwardResponseMessage
+	forward_MyTenant_GetMyPasswordPolicy_0                  = runtime.ForwardResponseMessage
+	forward_MyTenant_UpdateMyPasswordPolicy_0               = runtime.ForwardResponseMessage
+	forward_MyTenant_GetKeycloakSessionLimitsInstructions_0 = runtime.ForwardResponseMessage
+	forward_MyTenant_ConfigureKeycloakSessionLimits_0       = runtime.ForwardResponseMessage
 )

--- a/api/mytenant.pb.route.go
+++ b/api/mytenant.pb.route.go
@@ -21,4 +21,16 @@ func init() {
 	route.Resource = "password-policy"
 	route.Verb = "update"
 	RoutesMyTenant = append(RoutesMyTenant, route)
+
+	// Adding Route information for GetKeycloakSessionLimitsInstructions RPC
+	route = model.NewRoute("/api/mytenant/v1/keycloak-session-limits", "GET")
+	route.Resource = "session-limits"
+	route.Verb = "get"
+	RoutesMyTenant = append(RoutesMyTenant, route)
+
+	// Adding Route information for ConfigureKeycloakSessionLimits RPC
+	route = model.NewRoute("/api/mytenant/v1/keycloak-session-limits", "PUT")
+	route.Resource = "session-limits"
+	route.Verb = "update"
+	RoutesMyTenant = append(RoutesMyTenant, route)
 }

--- a/api/mytenant.proto
+++ b/api/mytenant.proto
@@ -34,6 +34,29 @@ service MyTenant {
       verb: "update"
     };
   }
+
+  // Get Keycloak session limits configuration instructions
+  rpc GetKeycloakSessionLimitsInstructions(GetKeycloakSessionLimitsInstructionsReq) returns (GetKeycloakSessionLimitsInstructionsResp) {
+    option (google.api.http) = {
+      get: "/api/mytenant/v1/keycloak-session-limits"
+    };
+    option (api.role) = {
+      resource: "session-limits"
+      verb: "get"
+    };
+  }
+
+  // Configure session limits in Keycloak realm (preparation step)
+  rpc ConfigureKeycloakSessionLimits(ConfigureKeycloakSessionLimitsReq) returns (ConfigureKeycloakSessionLimitsResp) {
+    option (google.api.http) = {
+      put: "/api/mytenant/v1/keycloak-session-limits"
+      body: "*"
+    };
+    option (api.role) = {
+      resource: "session-limits"
+      verb: "update"
+    };
+  }
 }
 
 // password policy get request
@@ -102,4 +125,51 @@ message MyPasswordPolicyUpdateReq {
 
 // password policy update response
 message MyPasswordPolicyUpdateResp {
+}
+
+// behavior when session limit is exceeded
+enum SessionLimitBehavior {
+  // deny new session (reject login)
+  DENY = 0;
+  // terminate oldest session to allow new login
+  TERMINATE = 1;
+}
+
+// Keycloak session limits configuration
+message KeycloakSessionLimitsConfig {
+  // maximum number of concurrent sessions per user
+  int32 max_concurrent_sessions = 1;
+  
+  // behavior when limit is exceeded
+  SessionLimitBehavior behavior_when_limit_exceeded = 2;
+}
+
+// get Keycloak session limits instructions request
+message GetKeycloakSessionLimitsInstructionsReq {
+  // optional configuration to generate specific instructions
+  KeycloakSessionLimitsConfig config = 1;
+}
+
+// get Keycloak session limits instructions response
+message GetKeycloakSessionLimitsInstructionsResp {
+  // step-by-step instructions for manual configuration
+  string instructions = 1;
+  
+  // current realm name
+  string realm = 2;
+}
+
+// configure Keycloak session limits request
+message ConfigureKeycloakSessionLimitsReq {
+  // session limits configuration
+  KeycloakSessionLimitsConfig config = 1;
+}
+
+// configure Keycloak session limits response
+message ConfigureKeycloakSessionLimitsResp {
+  // success message
+  string message = 1;
+  
+  // manual configuration instructions
+  string instructions = 2;
 }

--- a/api/mytenant_grpc.pb.go
+++ b/api/mytenant_grpc.pb.go
@@ -22,8 +22,10 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	MyTenant_GetMyPasswordPolicy_FullMethodName    = "/api.MyTenant/GetMyPasswordPolicy"
-	MyTenant_UpdateMyPasswordPolicy_FullMethodName = "/api.MyTenant/UpdateMyPasswordPolicy"
+	MyTenant_GetMyPasswordPolicy_FullMethodName                  = "/api.MyTenant/GetMyPasswordPolicy"
+	MyTenant_UpdateMyPasswordPolicy_FullMethodName               = "/api.MyTenant/UpdateMyPasswordPolicy"
+	MyTenant_GetKeycloakSessionLimitsInstructions_FullMethodName = "/api.MyTenant/GetKeycloakSessionLimitsInstructions"
+	MyTenant_ConfigureKeycloakSessionLimits_FullMethodName       = "/api.MyTenant/ConfigureKeycloakSessionLimits"
 )
 
 // MyTenantClient is the client API for MyTenant service.
@@ -36,6 +38,10 @@ type MyTenantClient interface {
 	GetMyPasswordPolicy(ctx context.Context, in *MyPasswordPolicyGetReq, opts ...grpc.CallOption) (*MyPasswordPolicyGetResp, error)
 	// Update Password policy configuration
 	UpdateMyPasswordPolicy(ctx context.Context, in *MyPasswordPolicyUpdateReq, opts ...grpc.CallOption) (*MyPasswordPolicyUpdateResp, error)
+	// Get Keycloak session limits configuration instructions
+	GetKeycloakSessionLimitsInstructions(ctx context.Context, in *GetKeycloakSessionLimitsInstructionsReq, opts ...grpc.CallOption) (*GetKeycloakSessionLimitsInstructionsResp, error)
+	// Configure session limits in Keycloak realm (preparation step)
+	ConfigureKeycloakSessionLimits(ctx context.Context, in *ConfigureKeycloakSessionLimitsReq, opts ...grpc.CallOption) (*ConfigureKeycloakSessionLimitsResp, error)
 }
 
 type myTenantClient struct {
@@ -66,6 +72,26 @@ func (c *myTenantClient) UpdateMyPasswordPolicy(ctx context.Context, in *MyPassw
 	return out, nil
 }
 
+func (c *myTenantClient) GetKeycloakSessionLimitsInstructions(ctx context.Context, in *GetKeycloakSessionLimitsInstructionsReq, opts ...grpc.CallOption) (*GetKeycloakSessionLimitsInstructionsResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetKeycloakSessionLimitsInstructionsResp)
+	err := c.cc.Invoke(ctx, MyTenant_GetKeycloakSessionLimitsInstructions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *myTenantClient) ConfigureKeycloakSessionLimits(ctx context.Context, in *ConfigureKeycloakSessionLimitsReq, opts ...grpc.CallOption) (*ConfigureKeycloakSessionLimitsResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ConfigureKeycloakSessionLimitsResp)
+	err := c.cc.Invoke(ctx, MyTenant_ConfigureKeycloakSessionLimits_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MyTenantServer is the server API for MyTenant service.
 // All implementations must embed UnimplementedMyTenantServer
 // for forward compatibility.
@@ -76,6 +102,10 @@ type MyTenantServer interface {
 	GetMyPasswordPolicy(context.Context, *MyPasswordPolicyGetReq) (*MyPasswordPolicyGetResp, error)
 	// Update Password policy configuration
 	UpdateMyPasswordPolicy(context.Context, *MyPasswordPolicyUpdateReq) (*MyPasswordPolicyUpdateResp, error)
+	// Get Keycloak session limits configuration instructions
+	GetKeycloakSessionLimitsInstructions(context.Context, *GetKeycloakSessionLimitsInstructionsReq) (*GetKeycloakSessionLimitsInstructionsResp, error)
+	// Configure session limits in Keycloak realm (preparation step)
+	ConfigureKeycloakSessionLimits(context.Context, *ConfigureKeycloakSessionLimitsReq) (*ConfigureKeycloakSessionLimitsResp, error)
 	mustEmbedUnimplementedMyTenantServer()
 }
 
@@ -91,6 +121,12 @@ func (UnimplementedMyTenantServer) GetMyPasswordPolicy(context.Context, *MyPassw
 }
 func (UnimplementedMyTenantServer) UpdateMyPasswordPolicy(context.Context, *MyPasswordPolicyUpdateReq) (*MyPasswordPolicyUpdateResp, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateMyPasswordPolicy not implemented")
+}
+func (UnimplementedMyTenantServer) GetKeycloakSessionLimitsInstructions(context.Context, *GetKeycloakSessionLimitsInstructionsReq) (*GetKeycloakSessionLimitsInstructionsResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetKeycloakSessionLimitsInstructions not implemented")
+}
+func (UnimplementedMyTenantServer) ConfigureKeycloakSessionLimits(context.Context, *ConfigureKeycloakSessionLimitsReq) (*ConfigureKeycloakSessionLimitsResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ConfigureKeycloakSessionLimits not implemented")
 }
 func (UnimplementedMyTenantServer) mustEmbedUnimplementedMyTenantServer() {}
 func (UnimplementedMyTenantServer) testEmbeddedByValue()                  {}
@@ -149,6 +185,42 @@ func _MyTenant_UpdateMyPasswordPolicy_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MyTenant_GetKeycloakSessionLimitsInstructions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetKeycloakSessionLimitsInstructionsReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MyTenantServer).GetKeycloakSessionLimitsInstructions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MyTenant_GetKeycloakSessionLimitsInstructions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MyTenantServer).GetKeycloakSessionLimitsInstructions(ctx, req.(*GetKeycloakSessionLimitsInstructionsReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MyTenant_ConfigureKeycloakSessionLimits_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ConfigureKeycloakSessionLimitsReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MyTenantServer).ConfigureKeycloakSessionLimits(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MyTenant_ConfigureKeycloakSessionLimits_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MyTenantServer).ConfigureKeycloakSessionLimits(ctx, req.(*ConfigureKeycloakSessionLimitsReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // MyTenant_ServiceDesc is the grpc.ServiceDesc for MyTenant service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -163,6 +235,14 @@ var MyTenant_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateMyPasswordPolicy",
 			Handler:    _MyTenant_UpdateMyPasswordPolicy_Handler,
+		},
+		{
+			MethodName: "GetKeycloakSessionLimitsInstructions",
+			Handler:    _MyTenant_GetKeycloakSessionLimitsInstructions_Handler,
+		},
+		{
+			MethodName: "ConfigureKeycloakSessionLimits",
+			Handler:    _MyTenant_ConfigureKeycloakSessionLimits_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/swagger/apidocs.swagger.json
+++ b/api/swagger/apidocs.swagger.json
@@ -1365,6 +1365,82 @@
         ]
       }
     },
+    "/api/mytenant/v1/keycloak-session-limits": {
+      "get": {
+        "summary": "Get Keycloak session limits configuration instructions",
+        "operationId": "MyTenant_GetKeycloakSessionLimitsInstructions",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiGetKeycloakSessionLimitsInstructionsResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "config.maxConcurrentSessions",
+            "description": "maximum number of concurrent sessions per user",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "config.behaviorWhenLimitExceeded",
+            "description": "behavior when limit is exceeded\n\n - DENY: deny new session (reject login)\n - TERMINATE: terminate oldest session to allow new login",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "DENY",
+              "TERMINATE"
+            ],
+            "default": "DENY"
+          }
+        ],
+        "tags": [
+          "MyTenant"
+        ]
+      },
+      "put": {
+        "summary": "Configure session limits in Keycloak realm (preparation step)",
+        "operationId": "MyTenant_ConfigureKeycloakSessionLimits",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiConfigureKeycloakSessionLimitsResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiConfigureKeycloakSessionLimitsReq"
+            }
+          }
+        ],
+        "tags": [
+          "MyTenant"
+        ]
+      }
+    },
     "/api/mytenant/v1/ou": {
       "post": {
         "summary": "Create new org unit for my tenant",
@@ -2203,6 +2279,30 @@
         }
       }
     },
+    "apiConfigureKeycloakSessionLimitsReq": {
+      "type": "object",
+      "properties": {
+        "config": {
+          "$ref": "#/definitions/apiKeycloakSessionLimitsConfig",
+          "title": "session limits configuration"
+        }
+      },
+      "title": "configure Keycloak session limits request"
+    },
+    "apiConfigureKeycloakSessionLimitsResp": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "title": "success message"
+        },
+        "instructions": {
+          "type": "string",
+          "title": "manual configuration instructions"
+        }
+      },
+      "title": "configure Keycloak session limits response"
+    },
     "apiCustomerAddReq": {
       "type": "object",
       "properties": {
@@ -2309,6 +2409,35 @@
     },
     "apiDefaultOrgUnitResp": {
       "type": "object"
+    },
+    "apiGetKeycloakSessionLimitsInstructionsResp": {
+      "type": "object",
+      "properties": {
+        "instructions": {
+          "type": "string",
+          "title": "step-by-step instructions for manual configuration"
+        },
+        "realm": {
+          "type": "string",
+          "title": "current realm name"
+        }
+      },
+      "title": "get Keycloak session limits instructions response"
+    },
+    "apiKeycloakSessionLimitsConfig": {
+      "type": "object",
+      "properties": {
+        "maxConcurrentSessions": {
+          "type": "integer",
+          "format": "int32",
+          "title": "maximum number of concurrent sessions per user"
+        },
+        "behaviorWhenLimitExceeded": {
+          "$ref": "#/definitions/apiSessionLimitBehavior",
+          "title": "behavior when limit is exceeded"
+        }
+      },
+      "title": "Keycloak session limits configuration"
     },
     "apiMyAzsListEntry": {
       "type": "object",
@@ -2805,6 +2934,16 @@
         }
       },
       "title": "resource get response"
+    },
+    "apiSessionLimitBehavior": {
+      "type": "string",
+      "enum": [
+        "DENY",
+        "TERMINATE"
+      ],
+      "default": "DENY",
+      "description": "- DENY: deny new session (reject login)\n - TERMINATE: terminate oldest session to allow new login",
+      "title": "behavior when session limit is exceeded"
     },
     "apiTenantAdminCreateConfig": {
       "type": "object",

--- a/pkg/keycloak/client.go
+++ b/pkg/keycloak/client.go
@@ -6,6 +6,7 @@ package keycloak
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"log"
 	"strings"
 	"sync"
@@ -235,4 +236,274 @@ func (c *Client) GetClientUserSessionsCount(ctx context.Context, token, realm, i
 	}
 
 	return result.Count, nil
+}
+
+// SessionLimitConfig represents the configuration for User session count limiter authenticator
+type SessionLimitConfig struct {
+	// Maximum concurrent sessions per user within the realm
+	MaxConcurrentSessions int `json:"maxConcurrentSessions"`
+	
+	// Behavior when limit is exceeded: "deny" (reject login) or "terminate" (kill oldest session)
+	BehaviorWhenLimitExceeded string `json:"behaviorWhenLimitExceeded"`
+}
+
+// AuthenticationFlow represents a Keycloak authentication flow
+type AuthenticationFlow struct {
+	ID          string `json:"id,omitempty"`
+	Alias       string `json:"alias,omitempty"`
+	Description string `json:"description,omitempty"`
+	TopLevel    bool   `json:"topLevel,omitempty"`
+	BuiltIn     bool   `json:"builtIn,omitempty"`
+}
+
+// AuthenticationExecution represents an execution in a Keycloak authentication flow
+type AuthenticationExecution struct {
+	ID            string `json:"id,omitempty"`
+	Alias         string `json:"alias,omitempty"`
+	Requirement   string `json:"requirement,omitempty"`
+	Priority      int    `json:"priority,omitempty"`
+	Authenticator string `json:"authenticator,omitempty"`
+	FlowID        string `json:"flowId,omitempty"`
+	ParentFlow    string `json:"parentFlow,omitempty"`
+}
+
+// AuthenticatorConfig represents the configuration for an authenticator execution
+type AuthenticatorConfig struct {
+	ID     string            `json:"id,omitempty"`
+	Alias  string            `json:"alias,omitempty"`
+	Config map[string]string `json:"config,omitempty"`
+}
+
+// ConfigureSessionLimitsInRealm fully automates the configuration of session limits in Keycloak
+// This creates a copy of the Browser flow, adds the User session count limiter execution, and sets it as the realm's Browser flow
+func (c *Client) ConfigureSessionLimitsInRealm(ctx context.Context, token, realm string, config SessionLimitConfig) error {
+	log.Printf("Starting automated session limits configuration for realm %s", realm)
+
+	// Get admin token for the target realm using admin-cli client
+	adminToken, err := c.getRootRealmAdminToken(ctx, realm)
+	if err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "failed to get admin token: %v", err)
+	}
+
+	// Step 1: Get existing Browser flow
+	browserFlow, err := c.getAuthenticationFlow(ctx, adminToken, realm, "browser")
+	if err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "failed to get browser flow: %v", err)
+	}
+
+	// Step 2: Create a copy of the Browser flow
+	newFlowAlias := "browser-with-session-limits"
+	newFlow, err := c.copyAuthenticationFlow(ctx, adminToken, realm, browserFlow.Alias, newFlowAlias)
+	if err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "failed to copy browser flow: %v", err)
+	}
+
+	// Step 3: Add User session count limiter execution to the copied flow
+	execution, err := c.addUserSessionLimiterExecution(ctx, adminToken, realm, newFlow.Alias)
+	if err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "failed to add session limiter execution: %v", err)
+	}
+
+	// Step 4: Configure the execution with session limits
+	err = c.configureSessionLimiterExecution(ctx, adminToken, realm, execution.ID, config)
+	if err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "failed to configure session limiter execution: %v", err)
+	}
+
+	// Step 5: Set the new flow as the realm's Browser flow
+	err = c.setRealmBrowserFlow(ctx, adminToken, realm, newFlowAlias)
+	if err != nil {
+		return errors.Wrapf(errors.InvalidArgument, "failed to set realm browser flow: %v", err)
+	}
+
+	log.Printf("Successfully configured automated session limits for realm %s with flow %s", realm, newFlowAlias)
+	return nil
+}
+
+// getRootRealmAdminToken gets an admin token specifically for the target realm using admin-cli
+func (c *Client) getRootRealmAdminToken(ctx context.Context, realm string) (string, error) {
+	// Use admin-cli client which has full admin permissions
+	token, err := c.Login(ctx, "admin-cli", "", realm, getKeycloakUsername(), getKeycloakPassword())
+	if err != nil {
+		return "", fmt.Errorf("failed to get %s realm admin token: %v", realm, err)
+	}
+	return token.AccessToken, nil
+}
+
+// getRealmAdminToken gets an admin token for a specific realm using admin-cli client
+func (c *Client) getRealmAdminToken(ctx context.Context, realm string) (string, error) {
+	// Use admin-cli client which has full admin permissions
+	token, err := c.Login(ctx, "admin-cli", "", realm, getKeycloakUsername(), getKeycloakPassword())
+	if err != nil {
+		return "", fmt.Errorf("failed to login as admin to realm %s: %v", realm, err)
+	}
+	return token.AccessToken, nil
+}
+
+// getAuthenticationFlow retrieves an authentication flow by alias
+func (c *Client) getAuthenticationFlow(ctx context.Context, token, realm, alias string) (*AuthenticationFlow, error) {
+	var flows []AuthenticationFlow
+	resp, err := c.GetRequestWithBearerAuth(ctx, token).
+		SetResult(&flows).
+		Get(c.getAdminRealmURL(c.url, realm, "authentication", "flows"))
+	
+	if resp == nil || err != nil {
+		return nil, fmt.Errorf("failed to get authentication flows: %v", err)
+	}
+	
+	if resp.IsError() {
+		return nil, fmt.Errorf("failed to get authentication flows: HTTP %d - %s", resp.StatusCode(), string(resp.Body()))
+	}
+
+	for _, flow := range flows {
+		if flow.Alias == alias {
+			log.Printf("Found authentication flow: %s (ID: %s)", flow.Alias, flow.ID)
+			return &flow, nil
+		}
+	}
+
+	return nil, fmt.Errorf("authentication flow '%s' not found", alias)
+}
+
+// copyAuthenticationFlow creates a copy of an existing authentication flow
+func (c *Client) copyAuthenticationFlow(ctx context.Context, token, realm, sourceAlias, newAlias string) (*AuthenticationFlow, error) {
+	copyRequest := map[string]string{
+		"newName": newAlias,
+	}
+
+	resp, err := c.GetRequestWithBearerAuth(ctx, token).
+		SetHeader("Content-Type", "application/json").
+		SetBody(copyRequest).
+		Post(c.getAdminRealmURL(c.url, realm, "authentication", "flows", sourceAlias, "copy"))
+	
+	if resp == nil || err != nil {
+		return nil, fmt.Errorf("failed to copy authentication flow: %v", err)
+	}
+	
+	if resp.IsError() {
+		return nil, fmt.Errorf("failed to copy authentication flow: HTTP %d - %s", resp.StatusCode(), string(resp.Body()))
+	}
+
+	log.Printf("Successfully copied authentication flow '%s' to '%s'", sourceAlias, newAlias)
+
+	// Get the newly created flow
+	return c.getAuthenticationFlow(ctx, token, realm, newAlias)
+}
+
+// addUserSessionLimiterExecution adds a User session count limiter execution to a flow
+func (c *Client) addUserSessionLimiterExecution(ctx context.Context, token, realm, flowAlias string) (*AuthenticationExecution, error) {
+	executionRequest := map[string]string{
+		"provider": "user-session-limits",
+	}
+
+	resp, err := c.GetRequestWithBearerAuth(ctx, token).
+		SetBody(executionRequest).
+		Post(c.getAdminRealmURL(c.url, realm, "authentication", "flows", flowAlias, "executions", "execution"))
+	
+	if resp == nil || resp.IsError() || err != nil {
+		return nil, fmt.Errorf("failed to add user session limiter execution: %v", err)
+	}
+
+	// Get the executions for the flow to find the newly added one
+	executions, err := c.getFlowExecutions(ctx, token, realm, flowAlias)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get flow executions: %v", err)
+	}
+
+	// Find the user-session-limits execution
+	for _, execution := range executions {
+		if execution.Authenticator == "user-session-limits" {
+			return &execution, nil
+		}
+	}
+
+	return nil, fmt.Errorf("failed to find newly created user session limiter execution")
+}
+
+// getFlowExecutions retrieves all executions for a given flow
+func (c *Client) getFlowExecutions(ctx context.Context, token, realm, flowAlias string) ([]AuthenticationExecution, error) {
+	var executions []AuthenticationExecution
+	resp, err := c.GetRequestWithBearerAuth(ctx, token).
+		SetResult(&executions).
+		Get(c.getAdminRealmURL(c.url, realm, "authentication", "flows", flowAlias, "executions"))
+	
+	if resp == nil || resp.IsError() || err != nil {
+		return nil, fmt.Errorf("failed to get flow executions: %v", err)
+	}
+
+	return executions, nil
+}
+
+// configureSessionLimiterExecution configures the User session count limiter execution
+func (c *Client) configureSessionLimiterExecution(ctx context.Context, token, realm, executionID string, config SessionLimitConfig) error {
+	configRequest := AuthenticatorConfig{
+		Alias: "session-limits-config",
+		Config: map[string]string{
+			"max-sessions":               fmt.Sprintf("%d", config.MaxConcurrentSessions),
+			"session-limit-action":       config.BehaviorWhenLimitExceeded,
+		},
+	}
+
+	resp, err := c.GetRequestWithBearerAuth(ctx, token).
+		SetBody(configRequest).
+		Post(c.getAdminRealmURL(c.url, realm, "authentication", "executions", executionID, "config"))
+	
+	if resp == nil || resp.IsError() || err != nil {
+		return fmt.Errorf("failed to configure session limiter execution: %v", err)
+	}
+
+	// Set the execution requirement to REQUIRED
+	updateRequest := map[string]string{
+		"requirement": "REQUIRED",
+	}
+
+	resp, err = c.GetRequestWithBearerAuth(ctx, token).
+		SetBody(updateRequest).
+		Put(c.getAdminRealmURL(c.url, realm, "authentication", "flows", "executions"))
+	
+	if resp != nil && resp.IsError() {
+		log.Printf("Warning: failed to set execution requirement to REQUIRED: %v", err)
+	}
+
+	return nil
+}
+
+// setRealmBrowserFlow sets the realm's Browser flow to the specified flow
+func (c *Client) setRealmBrowserFlow(ctx context.Context, token, realm, flowAlias string) error {
+	// Get current realm settings
+	realmRep, err := c.GetRealm(ctx, token, realm)
+	if err != nil {
+		return fmt.Errorf("failed to get realm: %v", err)
+	}
+
+	// Update the Browser flow
+	realmRep.BrowserFlow = gocloak.StringP(flowAlias)
+
+	// Update the realm
+	err = c.UpdateRealm(ctx, token, *realmRep)
+	if err != nil {
+		return fmt.Errorf("failed to update realm browser flow: %v", err)
+	}
+
+	return nil
+}
+
+// GetSessionLimitsConfiguration returns instructions for manual configuration
+func (c *Client) GetSessionLimitsConfiguration(realm string, config SessionLimitConfig) string {
+	instructions := `
+To configure User Session Count Limiter in Keycloak:
+
+1. Go to Keycloak Admin Console
+2. Navigate to Authentication → Flows
+3. Copy the 'Browser' flow (or create a new flow)
+4. Add execution: "User session count limiter"
+5. Configure the execution with:
+   - Maximum concurrent sessions: %d
+   - Behavior when limit exceeded: %s
+6. Set the flow as your realm's Browser flow
+7. Save the configuration
+
+Realm: %s
+`
+	return fmt.Sprintf(instructions, config.MaxConcurrentSessions, config.BehaviorWhenLimitExceeded, realm)
 }


### PR DESCRIPTION
Implement a comprehensive User Session Configuration feature for auth-gateway that enables tenant administrators to manage concurrent session limits, session timeouts, and session enforcement policies.

Key features added:
- REST API endpoints for session configuration management
- Real-time session enforcement with configurable actions
- Keycloak integration for session timeout management
- Performance optimization with thread-safe caching
- Comprehensive validation and error handling

API Changes:
- Add GET /api/mytenant/v1/session-config endpoint
- Add PUT /api/mytenant/v1/session-config endpoint
- Add SessionConfig protobuf message with session limits and timeouts
- Add SessionLimitAction enum for TERMINATE_OLDEST and DENY_NEW policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tenant-scoped APIs to manage Keycloak session limits: GET returns realm-aware instructions; PUT accepts limits and returns a success message plus instructions.
  * Configure maximum concurrent sessions and choose behavior when limits are exceeded (DENY or TERMINATE).
  * Server can optionally apply settings to Keycloak; if integration is unavailable, APIs still provide manual setup instructions.

* **Documentation**
  * API docs (Swagger) updated with new endpoints, request/response schemas, config model, and behavior enum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->