### PR TITLE
feat: implement Identity Provider provisioning system

### DIFF
--- a/api/mytenant.pb.go
+++ b/api/mytenant.pb.go
@@ -27,59 +27,56 @@ const (
 )
 
 // Identity Provider types
-type IdpProviderType int32
+type IdentityProviderDefs_Type int32
 
 const (
-	IdpProviderType_IdentityProviderUnspecified IdpProviderType = 0
-	IdpProviderType_Google                      IdpProviderType = 1
-	IdpProviderType_Microsoft                   IdpProviderType = 2
-	IdpProviderType_OIDC                        IdpProviderType = 3
-	IdpProviderType_SAML                        IdpProviderType = 4
+	// Unspecified IDP
+	IdentityProviderDefs_IdentityProviderUnspecified IdentityProviderDefs_Type = 0
+	// Identity Provider - Google
+	IdentityProviderDefs_Google IdentityProviderDefs_Type = 1
+	// Identity Provider - Microsoft
+	IdentityProviderDefs_Microsoft IdentityProviderDefs_Type = 2
 )
 
-// Enum value maps for IdpProviderType.
+// Enum value maps for IdentityProviderDefs_Type.
 var (
-	IdpProviderType_name = map[int32]string{
+	IdentityProviderDefs_Type_name = map[int32]string{
 		0: "IdentityProviderUnspecified",
 		1: "Google",
 		2: "Microsoft",
-		3: "OIDC",
-		4: "SAML",
 	}
-	IdpProviderType_value = map[string]int32{
+	IdentityProviderDefs_Type_value = map[string]int32{
 		"IdentityProviderUnspecified": 0,
 		"Google":                      1,
 		"Microsoft":                   2,
-		"OIDC":                        3,
-		"SAML":                        4,
 	}
 )
 
-func (x IdpProviderType) Enum() *IdpProviderType {
-	p := new(IdpProviderType)
+func (x IdentityProviderDefs_Type) Enum() *IdentityProviderDefs_Type {
+	p := new(IdentityProviderDefs_Type)
 	*p = x
 	return p
 }
 
-func (x IdpProviderType) String() string {
+func (x IdentityProviderDefs_Type) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (IdpProviderType) Descriptor() protoreflect.EnumDescriptor {
+func (IdentityProviderDefs_Type) Descriptor() protoreflect.EnumDescriptor {
 	return file_mytenant_proto_enumTypes[0].Descriptor()
 }
 
-func (IdpProviderType) Type() protoreflect.EnumType {
+func (IdentityProviderDefs_Type) Type() protoreflect.EnumType {
 	return &file_mytenant_proto_enumTypes[0]
 }
 
-func (x IdpProviderType) Number() protoreflect.EnumNumber {
+func (x IdentityProviderDefs_Type) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use IdpProviderType.Descriptor instead.
-func (IdpProviderType) EnumDescriptor() ([]byte, []int) {
-	return file_mytenant_proto_rawDescGZIP(), []int{0}
+// Deprecated: Use IdentityProviderDefs_Type.Descriptor instead.
+func (IdentityProviderDefs_Type) EnumDescriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{4, 0}
 }
 
 // password policy get request
@@ -392,6 +389,42 @@ func (*MyPasswordPolicyUpdateResp) Descriptor() ([]byte, []int) {
 	return file_mytenant_proto_rawDescGZIP(), []int{3}
 }
 
+type IdentityProviderDefs struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdentityProviderDefs) Reset() {
+	*x = IdentityProviderDefs{}
+	mi := &file_mytenant_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdentityProviderDefs) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdentityProviderDefs) ProtoMessage() {}
+
+func (x *IdentityProviderDefs) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdentityProviderDefs.ProtoReflect.Descriptor instead.
+func (*IdentityProviderDefs) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{4}
+}
+
 // Configuration field metadata for validation
 type IdpConfigField struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -408,7 +441,7 @@ type IdpConfigField struct {
 
 func (x *IdpConfigField) Reset() {
 	*x = IdpConfigField{}
-	mi := &file_mytenant_proto_msgTypes[4]
+	mi := &file_mytenant_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -420,7 +453,7 @@ func (x *IdpConfigField) String() string {
 func (*IdpConfigField) ProtoMessage() {}
 
 func (x *IdpConfigField) ProtoReflect() protoreflect.Message {
-	mi := &file_mytenant_proto_msgTypes[4]
+	mi := &file_mytenant_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -433,7 +466,7 @@ func (x *IdpConfigField) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IdpConfigField.ProtoReflect.Descriptor instead.
 func (*IdpConfigField) Descriptor() ([]byte, []int) {
-	return file_mytenant_proto_rawDescGZIP(), []int{4}
+	return file_mytenant_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *IdpConfigField) GetName() string {
@@ -485,122 +518,27 @@ func (x *IdpConfigField) GetValidation() string {
 	return ""
 }
 
-// Provider metadata
-type IdpProviderMetadata struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	ProviderType    IdpProviderType        `protobuf:"varint,1,opt,name=provider_type,json=providerType,proto3,enum=api.IdpProviderType" json:"provider_type,omitempty"`
-	DisplayName     string                 `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
-	Description     string                 `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
-	ConfigFields    []*IdpConfigField      `protobuf:"bytes,4,rep,name=config_fields,json=configFields,proto3" json:"config_fields,omitempty"`
-	SupportedScopes []string               `protobuf:"bytes,5,rep,name=supported_scopes,json=supportedScopes,proto3" json:"supported_scopes,omitempty"`
-	DefaultScopes   []string               `protobuf:"bytes,6,rep,name=default_scopes,json=defaultScopes,proto3" json:"default_scopes,omitempty"`
-	Documentation   string                 `protobuf:"bytes,7,opt,name=documentation,proto3" json:"documentation,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
-}
-
-func (x *IdpProviderMetadata) Reset() {
-	*x = IdpProviderMetadata{}
-	mi := &file_mytenant_proto_msgTypes[5]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *IdpProviderMetadata) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*IdpProviderMetadata) ProtoMessage() {}
-
-func (x *IdpProviderMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_mytenant_proto_msgTypes[5]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use IdpProviderMetadata.ProtoReflect.Descriptor instead.
-func (*IdpProviderMetadata) Descriptor() ([]byte, []int) {
-	return file_mytenant_proto_rawDescGZIP(), []int{5}
-}
-
-func (x *IdpProviderMetadata) GetProviderType() IdpProviderType {
-	if x != nil {
-		return x.ProviderType
-	}
-	return IdpProviderType_IdentityProviderUnspecified
-}
-
-func (x *IdpProviderMetadata) GetDisplayName() string {
-	if x != nil {
-		return x.DisplayName
-	}
-	return ""
-}
-
-func (x *IdpProviderMetadata) GetDescription() string {
-	if x != nil {
-		return x.Description
-	}
-	return ""
-}
-
-func (x *IdpProviderMetadata) GetConfigFields() []*IdpConfigField {
-	if x != nil {
-		return x.ConfigFields
-	}
-	return nil
-}
-
-func (x *IdpProviderMetadata) GetSupportedScopes() []string {
-	if x != nil {
-		return x.SupportedScopes
-	}
-	return nil
-}
-
-func (x *IdpProviderMetadata) GetDefaultScopes() []string {
-	if x != nil {
-		return x.DefaultScopes
-	}
-	return nil
-}
-
-func (x *IdpProviderMetadata) GetDocumentation() string {
-	if x != nil {
-		return x.Documentation
-	}
-	return ""
-}
-
 // Identity provider providers request (list supported provider types)
-type IdpProvidersReq struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Optional filter by provider type
-	ProviderType  *IdpProviderType `protobuf:"varint,1,opt,name=providerType,proto3,enum=api.IdpProviderType,oneof" json:"providerType,omitempty"`
+type IdentityProviderTypesGetReq struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *IdpProvidersReq) Reset() {
-	*x = IdpProvidersReq{}
+func (x *IdentityProviderTypesGetReq) Reset() {
+	*x = IdentityProviderTypesGetReq{}
 	mi := &file_mytenant_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *IdpProvidersReq) String() string {
+func (x *IdentityProviderTypesGetReq) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*IdpProvidersReq) ProtoMessage() {}
+func (*IdentityProviderTypesGetReq) ProtoMessage() {}
 
-func (x *IdpProvidersReq) ProtoReflect() protoreflect.Message {
+func (x *IdentityProviderTypesGetReq) ProtoReflect() protoreflect.Message {
 	mi := &file_mytenant_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -612,41 +550,33 @@ func (x *IdpProvidersReq) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use IdpProvidersReq.ProtoReflect.Descriptor instead.
-func (*IdpProvidersReq) Descriptor() ([]byte, []int) {
+// Deprecated: Use IdentityProviderTypesGetReq.ProtoReflect.Descriptor instead.
+func (*IdentityProviderTypesGetReq) Descriptor() ([]byte, []int) {
 	return file_mytenant_proto_rawDescGZIP(), []int{6}
 }
 
-func (x *IdpProvidersReq) GetProviderType() IdpProviderType {
-	if x != nil && x.ProviderType != nil {
-		return *x.ProviderType
-	}
-	return IdpProviderType_IdentityProviderUnspecified
-}
-
-// Identity provider providers response
-type IdpProvidersResp struct {
+type IdentityProviderTypesListEntry struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Available provider types and their metadata
-	Providers     []*IdpProviderMetadata `protobuf:"bytes,1,rep,name=providers,proto3" json:"providers,omitempty"`
+	// type value for the list entry
+	Type          string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *IdpProvidersResp) Reset() {
-	*x = IdpProvidersResp{}
+func (x *IdentityProviderTypesListEntry) Reset() {
+	*x = IdentityProviderTypesListEntry{}
 	mi := &file_mytenant_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *IdpProvidersResp) String() string {
+func (x *IdentityProviderTypesListEntry) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*IdpProvidersResp) ProtoMessage() {}
+func (*IdentityProviderTypesListEntry) ProtoMessage() {}
 
-func (x *IdpProvidersResp) ProtoReflect() protoreflect.Message {
+func (x *IdentityProviderTypesListEntry) ProtoReflect() protoreflect.Message {
 	mi := &file_mytenant_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -658,52 +588,92 @@ func (x *IdpProvidersResp) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use IdpProvidersResp.ProtoReflect.Descriptor instead.
-func (*IdpProvidersResp) Descriptor() ([]byte, []int) {
+// Deprecated: Use IdentityProviderTypesListEntry.ProtoReflect.Descriptor instead.
+func (*IdentityProviderTypesListEntry) Descriptor() ([]byte, []int) {
 	return file_mytenant_proto_rawDescGZIP(), []int{7}
 }
 
-func (x *IdpProvidersResp) GetProviders() []*IdpProviderMetadata {
+func (x *IdentityProviderTypesListEntry) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+// Identity provider providers response
+type IdentityProviderTypesGetResp struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Available provider types
+	Providers     []*IdentityProviderTypesListEntry `protobuf:"bytes,1,rep,name=providers,proto3" json:"providers,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdentityProviderTypesGetResp) Reset() {
+	*x = IdentityProviderTypesGetResp{}
+	mi := &file_mytenant_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdentityProviderTypesGetResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdentityProviderTypesGetResp) ProtoMessage() {}
+
+func (x *IdentityProviderTypesGetResp) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdentityProviderTypesGetResp.ProtoReflect.Descriptor instead.
+func (*IdentityProviderTypesGetResp) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *IdentityProviderTypesGetResp) GetProviders() []*IdentityProviderTypesListEntry {
 	if x != nil {
 		return x.Providers
 	}
 	return nil
 }
 
-// Identity provider instance create request
-type IdpInstanceCreateReq struct {
+type GoogleIDPConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Identity provider key (unique per tenant)
-	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	// Display name
-	DisplayName string `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
-	// Provider type
-	ProviderType IdpProviderType `protobuf:"varint,3,opt,name=provider_type,json=providerType,proto3,enum=api.IdpProviderType" json:"provider_type,omitempty"`
-	// Whether configuration is enabled
-	Enabled bool `protobuf:"varint,4,opt,name=enabled,proto3" json:"enabled,omitempty"`
-	// Display order for UI
-	DisplayOrder int32 `protobuf:"varint,5,opt,name=display_order,json=displayOrder,proto3" json:"display_order,omitempty"`
-	// Provider configuration (including sensitive fields)
-	Configuration string `protobuf:"bytes,6,opt,name=configuration,proto3" json:"configuration,omitempty"`
+	// client id from google SSO config, where controller
+	// is enabled as client
+	ClientId string `protobuf:"bytes,1,opt,name=clientId,proto3" json:"clientId,omitempty"`
+	// client secret to validate ourself with google
+	ClientSecret string `protobuf:"bytes,2,opt,name=clientSecret,proto3" json:"clientSecret,omitempty"`
+	// Hosted Domain for allowing users only from specific domain
+	HostedDomain  string `protobuf:"bytes,3,opt,name=hostedDomain,proto3" json:"hostedDomain,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *IdpInstanceCreateReq) Reset() {
-	*x = IdpInstanceCreateReq{}
-	mi := &file_mytenant_proto_msgTypes[8]
+func (x *GoogleIDPConfig) Reset() {
+	*x = GoogleIDPConfig{}
+	mi := &file_mytenant_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *IdpInstanceCreateReq) String() string {
+func (x *GoogleIDPConfig) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*IdpInstanceCreateReq) ProtoMessage() {}
+func (*GoogleIDPConfig) ProtoMessage() {}
 
-func (x *IdpInstanceCreateReq) ProtoReflect() protoreflect.Message {
-	mi := &file_mytenant_proto_msgTypes[8]
+func (x *GoogleIDPConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -714,79 +684,211 @@ func (x *IdpInstanceCreateReq) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use IdpInstanceCreateReq.ProtoReflect.Descriptor instead.
-func (*IdpInstanceCreateReq) Descriptor() ([]byte, []int) {
-	return file_mytenant_proto_rawDescGZIP(), []int{8}
+// Deprecated: Use GoogleIDPConfig.ProtoReflect.Descriptor instead.
+func (*GoogleIDPConfig) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{9}
 }
 
-func (x *IdpInstanceCreateReq) GetKey() string {
+func (x *GoogleIDPConfig) GetClientId() string {
+	if x != nil {
+		return x.ClientId
+	}
+	return ""
+}
+
+func (x *GoogleIDPConfig) GetClientSecret() string {
+	if x != nil {
+		return x.ClientSecret
+	}
+	return ""
+}
+
+func (x *GoogleIDPConfig) GetHostedDomain() string {
+	if x != nil {
+		return x.HostedDomain
+	}
+	return ""
+}
+
+type MicrosoftIDPConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// client id from microsoft SSO config, where controller
+	// is enabled as client
+	ClientId string `protobuf:"bytes,1,opt,name=clientId,proto3" json:"clientId,omitempty"`
+	// client secret to validate ourself with microsoft
+	ClientSecret string `protobuf:"bytes,2,opt,name=clientSecret,proto3" json:"clientSecret,omitempty"`
+	// tenant id to ensure allowing users only from specific
+	// microsoft tenant
+	TenantId      string `protobuf:"bytes,3,opt,name=tenantId,proto3" json:"tenantId,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MicrosoftIDPConfig) Reset() {
+	*x = MicrosoftIDPConfig{}
+	mi := &file_mytenant_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MicrosoftIDPConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MicrosoftIDPConfig) ProtoMessage() {}
+
+func (x *MicrosoftIDPConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MicrosoftIDPConfig.ProtoReflect.Descriptor instead.
+func (*MicrosoftIDPConfig) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *MicrosoftIDPConfig) GetClientId() string {
+	if x != nil {
+		return x.ClientId
+	}
+	return ""
+}
+
+func (x *MicrosoftIDPConfig) GetClientSecret() string {
+	if x != nil {
+		return x.ClientSecret
+	}
+	return ""
+}
+
+func (x *MicrosoftIDPConfig) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
+	}
+	return ""
+}
+
+// Identity provider create request
+type MyIdentityProviderCreateReq struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Identity provider key (unique per tenant), also used for
+	// hosting SSO broker endpoint
+	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// Display name
+	DispName string `protobuf:"bytes,2,opt,name=dispName,proto3" json:"dispName,omitempty"`
+	// Provider type
+	Type IdentityProviderDefs_Type `protobuf:"varint,3,opt,name=type,proto3,enum=api.IdentityProviderDefs_Type" json:"type,omitempty"`
+	// Whether configuration is enabled
+	Enabled bool `protobuf:"varint,4,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	// configuration for Google Identity Provider
+	Google *GoogleIDPConfig `protobuf:"bytes,5,opt,name=google,proto3" json:"google,omitempty"`
+	// configuration for Microsoft Identity Provider
+	Microsoft     *MicrosoftIDPConfig `protobuf:"bytes,6,opt,name=microsoft,proto3" json:"microsoft,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MyIdentityProviderCreateReq) Reset() {
+	*x = MyIdentityProviderCreateReq{}
+	mi := &file_mytenant_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MyIdentityProviderCreateReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MyIdentityProviderCreateReq) ProtoMessage() {}
+
+func (x *MyIdentityProviderCreateReq) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MyIdentityProviderCreateReq.ProtoReflect.Descriptor instead.
+func (*MyIdentityProviderCreateReq) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *MyIdentityProviderCreateReq) GetKey() string {
 	if x != nil {
 		return x.Key
 	}
 	return ""
 }
 
-func (x *IdpInstanceCreateReq) GetDisplayName() string {
+func (x *MyIdentityProviderCreateReq) GetDispName() string {
 	if x != nil {
-		return x.DisplayName
+		return x.DispName
 	}
 	return ""
 }
 
-func (x *IdpInstanceCreateReq) GetProviderType() IdpProviderType {
+func (x *MyIdentityProviderCreateReq) GetType() IdentityProviderDefs_Type {
 	if x != nil {
-		return x.ProviderType
+		return x.Type
 	}
-	return IdpProviderType_IdentityProviderUnspecified
+	return IdentityProviderDefs_IdentityProviderUnspecified
 }
 
-func (x *IdpInstanceCreateReq) GetEnabled() bool {
+func (x *MyIdentityProviderCreateReq) GetEnabled() bool {
 	if x != nil {
 		return x.Enabled
 	}
 	return false
 }
 
-func (x *IdpInstanceCreateReq) GetDisplayOrder() int32 {
+func (x *MyIdentityProviderCreateReq) GetGoogle() *GoogleIDPConfig {
 	if x != nil {
-		return x.DisplayOrder
+		return x.Google
 	}
-	return 0
+	return nil
 }
 
-func (x *IdpInstanceCreateReq) GetConfiguration() string {
+func (x *MyIdentityProviderCreateReq) GetMicrosoft() *MicrosoftIDPConfig {
 	if x != nil {
-		return x.Configuration
+		return x.Microsoft
 	}
-	return ""
+	return nil
 }
 
-// Identity provider instance create response
-type IdpInstanceCreateResp struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Created identity provider key
-	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	// Success message
-	Message       string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+// Identity provider create response
+type MyIdentityProviderCreateResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *IdpInstanceCreateResp) Reset() {
-	*x = IdpInstanceCreateResp{}
-	mi := &file_mytenant_proto_msgTypes[9]
+func (x *MyIdentityProviderCreateResp) Reset() {
+	*x = MyIdentityProviderCreateResp{}
+	mi := &file_mytenant_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *IdpInstanceCreateResp) String() string {
+func (x *MyIdentityProviderCreateResp) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*IdpInstanceCreateResp) ProtoMessage() {}
+func (*MyIdentityProviderCreateResp) ProtoMessage() {}
 
-func (x *IdpInstanceCreateResp) ProtoReflect() protoreflect.Message {
-	mi := &file_mytenant_proto_msgTypes[9]
+func (x *MyIdentityProviderCreateResp) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -797,30 +899,16 @@ func (x *IdpInstanceCreateResp) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use IdpInstanceCreateResp.ProtoReflect.Descriptor instead.
-func (*IdpInstanceCreateResp) Descriptor() ([]byte, []int) {
-	return file_mytenant_proto_rawDescGZIP(), []int{9}
+// Deprecated: Use MyIdentityProviderCreateResp.ProtoReflect.Descriptor instead.
+func (*MyIdentityProviderCreateResp) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{12}
 }
 
-func (x *IdpInstanceCreateResp) GetKey() string {
-	if x != nil {
-		return x.Key
-	}
-	return ""
-}
-
-func (x *IdpInstanceCreateResp) GetMessage() string {
-	if x != nil {
-		return x.Message
-	}
-	return ""
-}
-
-// Identity provider instance list request
-type IdpInstanceListReq struct {
+// Identity provider list request
+type MyIdentityProvidersListReq struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Optional filter by provider type
-	ProviderType *IdpProviderType `protobuf:"varint,1,opt,name=provider_type,json=providerType,proto3,enum=api.IdpProviderType,oneof" json:"provider_type,omitempty"`
+	Type *IdentityProviderDefs_Type `protobuf:"varint,1,opt,name=type,proto3,enum=api.IdentityProviderDefs_Type,oneof" json:"type,omitempty"`
 	// Optional filter by enabled status
 	Enabled *bool `protobuf:"varint,2,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
 	// Optional pagination limit
@@ -831,21 +919,21 @@ type IdpInstanceListReq struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *IdpInstanceListReq) Reset() {
-	*x = IdpInstanceListReq{}
-	mi := &file_mytenant_proto_msgTypes[10]
+func (x *MyIdentityProvidersListReq) Reset() {
+	*x = MyIdentityProvidersListReq{}
+	mi := &file_mytenant_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *IdpInstanceListReq) String() string {
+func (x *MyIdentityProvidersListReq) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*IdpInstanceListReq) ProtoMessage() {}
+func (*MyIdentityProvidersListReq) ProtoMessage() {}
 
-func (x *IdpInstanceListReq) ProtoReflect() protoreflect.Message {
-	mi := &file_mytenant_proto_msgTypes[10]
+func (x *MyIdentityProvidersListReq) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -856,130 +944,71 @@ func (x *IdpInstanceListReq) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use IdpInstanceListReq.ProtoReflect.Descriptor instead.
-func (*IdpInstanceListReq) Descriptor() ([]byte, []int) {
-	return file_mytenant_proto_rawDescGZIP(), []int{10}
+// Deprecated: Use MyIdentityProvidersListReq.ProtoReflect.Descriptor instead.
+func (*MyIdentityProvidersListReq) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{13}
 }
 
-func (x *IdpInstanceListReq) GetProviderType() IdpProviderType {
-	if x != nil && x.ProviderType != nil {
-		return *x.ProviderType
+func (x *MyIdentityProvidersListReq) GetType() IdentityProviderDefs_Type {
+	if x != nil && x.Type != nil {
+		return *x.Type
 	}
-	return IdpProviderType_IdentityProviderUnspecified
+	return IdentityProviderDefs_IdentityProviderUnspecified
 }
 
-func (x *IdpInstanceListReq) GetEnabled() bool {
+func (x *MyIdentityProvidersListReq) GetEnabled() bool {
 	if x != nil && x.Enabled != nil {
 		return *x.Enabled
 	}
 	return false
 }
 
-func (x *IdpInstanceListReq) GetLimit() int32 {
+func (x *MyIdentityProvidersListReq) GetLimit() int32 {
 	if x != nil && x.Limit != nil {
 		return *x.Limit
 	}
 	return 0
 }
 
-func (x *IdpInstanceListReq) GetOffset() int32 {
+func (x *MyIdentityProvidersListReq) GetOffset() int32 {
 	if x != nil && x.Offset != nil {
 		return *x.Offset
 	}
 	return 0
 }
 
-// Identity provider instance list response
-type IdpInstanceListResp struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// List of identity provider instances
-	Instances []*IdpInstanceSummary `protobuf:"bytes,1,rep,name=instances,proto3" json:"instances,omitempty"`
-	// Total count of instances (for pagination)
-	TotalCount    int32 `protobuf:"varint,2,opt,name=total_count,json=totalCount,proto3" json:"total_count,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *IdpInstanceListResp) Reset() {
-	*x = IdpInstanceListResp{}
-	mi := &file_mytenant_proto_msgTypes[11]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *IdpInstanceListResp) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*IdpInstanceListResp) ProtoMessage() {}
-
-func (x *IdpInstanceListResp) ProtoReflect() protoreflect.Message {
-	mi := &file_mytenant_proto_msgTypes[11]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use IdpInstanceListResp.ProtoReflect.Descriptor instead.
-func (*IdpInstanceListResp) Descriptor() ([]byte, []int) {
-	return file_mytenant_proto_rawDescGZIP(), []int{11}
-}
-
-func (x *IdpInstanceListResp) GetInstances() []*IdpInstanceSummary {
-	if x != nil {
-		return x.Instances
-	}
-	return nil
-}
-
-func (x *IdpInstanceListResp) GetTotalCount() int32 {
-	if x != nil {
-		return x.TotalCount
-	}
-	return 0
-}
-
-// Identity provider instance summary (for list responses)
-type IdpInstanceSummary struct {
+// Identity provider list entry
+type MyIdentityProvidersListEntry struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Identity provider key
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// Display name
-	DisplayName string `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	DispName string `protobuf:"bytes,2,opt,name=dispName,proto3" json:"dispName,omitempty"`
 	// Provider type
-	ProviderType IdpProviderType `protobuf:"varint,3,opt,name=provider_type,json=providerType,proto3,enum=api.IdpProviderType" json:"provider_type,omitempty"`
+	Type IdentityProviderDefs_Type `protobuf:"varint,3,opt,name=type,proto3,enum=api.IdentityProviderDefs_Type" json:"type,omitempty"`
 	// Whether configuration is enabled
 	Enabled bool `protobuf:"varint,4,opt,name=enabled,proto3" json:"enabled,omitempty"`
-	// Display order for UI
-	DisplayOrder int32 `protobuf:"varint,5,opt,name=display_order,json=displayOrder,proto3" json:"display_order,omitempty"`
 	// Created timestamp
-	Created int64 `protobuf:"varint,6,opt,name=created,proto3" json:"created,omitempty"`
-	// Updated timestamp
-	Updated       int64 `protobuf:"varint,7,opt,name=updated,proto3" json:"updated,omitempty"`
+	Created       int64 `protobuf:"varint,5,opt,name=created,proto3" json:"created,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *IdpInstanceSummary) Reset() {
-	*x = IdpInstanceSummary{}
-	mi := &file_mytenant_proto_msgTypes[12]
+func (x *MyIdentityProvidersListEntry) Reset() {
+	*x = MyIdentityProvidersListEntry{}
+	mi := &file_mytenant_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *IdpInstanceSummary) String() string {
+func (x *MyIdentityProvidersListEntry) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*IdpInstanceSummary) ProtoMessage() {}
+func (*MyIdentityProvidersListEntry) ProtoMessage() {}
 
-func (x *IdpInstanceSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_mytenant_proto_msgTypes[12]
+func (x *MyIdentityProvidersListEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -990,62 +1019,103 @@ func (x *IdpInstanceSummary) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use IdpInstanceSummary.ProtoReflect.Descriptor instead.
-func (*IdpInstanceSummary) Descriptor() ([]byte, []int) {
-	return file_mytenant_proto_rawDescGZIP(), []int{12}
+// Deprecated: Use MyIdentityProvidersListEntry.ProtoReflect.Descriptor instead.
+func (*MyIdentityProvidersListEntry) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{14}
 }
 
-func (x *IdpInstanceSummary) GetKey() string {
+func (x *MyIdentityProvidersListEntry) GetKey() string {
 	if x != nil {
 		return x.Key
 	}
 	return ""
 }
 
-func (x *IdpInstanceSummary) GetDisplayName() string {
+func (x *MyIdentityProvidersListEntry) GetDispName() string {
 	if x != nil {
-		return x.DisplayName
+		return x.DispName
 	}
 	return ""
 }
 
-func (x *IdpInstanceSummary) GetProviderType() IdpProviderType {
+func (x *MyIdentityProvidersListEntry) GetType() IdentityProviderDefs_Type {
 	if x != nil {
-		return x.ProviderType
+		return x.Type
 	}
-	return IdpProviderType_IdentityProviderUnspecified
+	return IdentityProviderDefs_IdentityProviderUnspecified
 }
 
-func (x *IdpInstanceSummary) GetEnabled() bool {
+func (x *MyIdentityProvidersListEntry) GetEnabled() bool {
 	if x != nil {
 		return x.Enabled
 	}
 	return false
 }
 
-func (x *IdpInstanceSummary) GetDisplayOrder() int32 {
-	if x != nil {
-		return x.DisplayOrder
-	}
-	return 0
-}
-
-func (x *IdpInstanceSummary) GetCreated() int64 {
+func (x *MyIdentityProvidersListEntry) GetCreated() int64 {
 	if x != nil {
 		return x.Created
 	}
 	return 0
 }
 
-func (x *IdpInstanceSummary) GetUpdated() int64 {
+// Identity provider instance list response
+type MyIdentityProvidersListResp struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Count of IDP available
+	Count int32 `protobuf:"varint,1,opt,name=count,proto3" json:"count,omitempty"`
+	// List of identity providers
+	Items         []*MyIdentityProvidersListEntry `protobuf:"bytes,2,rep,name=items,proto3" json:"items,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MyIdentityProvidersListResp) Reset() {
+	*x = MyIdentityProvidersListResp{}
+	mi := &file_mytenant_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MyIdentityProvidersListResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MyIdentityProvidersListResp) ProtoMessage() {}
+
+func (x *MyIdentityProvidersListResp) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[15]
 	if x != nil {
-		return x.Updated
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MyIdentityProvidersListResp.ProtoReflect.Descriptor instead.
+func (*MyIdentityProvidersListResp) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *MyIdentityProvidersListResp) GetCount() int32 {
+	if x != nil {
+		return x.Count
 	}
 	return 0
 }
 
-// Identity provider instance get request
-type IdpInstanceGetReq struct {
+func (x *MyIdentityProvidersListResp) GetItems() []*MyIdentityProvidersListEntry {
+	if x != nil {
+		return x.Items
+	}
+	return nil
+}
+
+// Identity provider get request
+type MyIdentityProviderGetReq struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Identity provider key
 	Key           string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
@@ -1053,21 +1123,21 @@ type IdpInstanceGetReq struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *IdpInstanceGetReq) Reset() {
-	*x = IdpInstanceGetReq{}
-	mi := &file_mytenant_proto_msgTypes[13]
+func (x *MyIdentityProviderGetReq) Reset() {
+	*x = MyIdentityProviderGetReq{}
+	mi := &file_mytenant_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *IdpInstanceGetReq) String() string {
+func (x *MyIdentityProviderGetReq) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*IdpInstanceGetReq) ProtoMessage() {}
+func (*MyIdentityProviderGetReq) ProtoMessage() {}
 
-func (x *IdpInstanceGetReq) ProtoReflect() protoreflect.Message {
-	mi := &file_mytenant_proto_msgTypes[13]
+func (x *MyIdentityProviderGetReq) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1078,60 +1148,56 @@ func (x *IdpInstanceGetReq) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use IdpInstanceGetReq.ProtoReflect.Descriptor instead.
-func (*IdpInstanceGetReq) Descriptor() ([]byte, []int) {
-	return file_mytenant_proto_rawDescGZIP(), []int{13}
+// Deprecated: Use MyIdentityProviderGetReq.ProtoReflect.Descriptor instead.
+func (*MyIdentityProviderGetReq) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{16}
 }
 
-func (x *IdpInstanceGetReq) GetKey() string {
+func (x *MyIdentityProviderGetReq) GetKey() string {
 	if x != nil {
 		return x.Key
 	}
 	return ""
 }
 
-// Identity provider instance get response
-type IdpInstanceGetResp struct {
+// Identity provider get response
+type MyIdentityProviderGetResp struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Identity provider key
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// Display name
-	DisplayName string `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	DispName string `protobuf:"bytes,2,opt,name=dispName,proto3" json:"dispName,omitempty"`
 	// Provider type
-	ProviderType IdpProviderType `protobuf:"varint,3,opt,name=provider_type,json=providerType,proto3,enum=api.IdpProviderType" json:"provider_type,omitempty"`
+	Type IdentityProviderDefs_Type `protobuf:"varint,3,opt,name=type,proto3,enum=api.IdentityProviderDefs_Type" json:"type,omitempty"`
 	// Whether configuration is enabled
 	Enabled bool `protobuf:"varint,4,opt,name=enabled,proto3" json:"enabled,omitempty"`
-	// Display order for UI
-	DisplayOrder int32 `protobuf:"varint,5,opt,name=display_order,json=displayOrder,proto3" json:"display_order,omitempty"`
-	// Provider configuration (non-sensitive fields only)
-	Configuration string `protobuf:"bytes,6,opt,name=configuration,proto3" json:"configuration,omitempty"`
 	// Created timestamp
-	Created int64 `protobuf:"varint,7,opt,name=created,proto3" json:"created,omitempty"`
-	// Updated timestamp
-	Updated int64 `protobuf:"varint,8,opt,name=updated,proto3" json:"updated,omitempty"`
+	Created int64 `protobuf:"varint,5,opt,name=created,proto3" json:"created,omitempty"`
 	// Created by user
-	CreatedBy string `protobuf:"bytes,9,opt,name=created_by,json=createdBy,proto3" json:"created_by,omitempty"`
-	// Updated by user
-	UpdatedBy     string `protobuf:"bytes,10,opt,name=updated_by,json=updatedBy,proto3" json:"updated_by,omitempty"`
+	CreatedBy string `protobuf:"bytes,6,opt,name=created_by,json=createdBy,proto3" json:"created_by,omitempty"`
+	// configuration for Google Identity Provider
+	Google *GoogleIDPConfig `protobuf:"bytes,7,opt,name=google,proto3" json:"google,omitempty"`
+	// configuration for Microsoft Identity Provider
+	Microsoft     *MicrosoftIDPConfig `protobuf:"bytes,8,opt,name=microsoft,proto3" json:"microsoft,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *IdpInstanceGetResp) Reset() {
-	*x = IdpInstanceGetResp{}
-	mi := &file_mytenant_proto_msgTypes[14]
+func (x *MyIdentityProviderGetResp) Reset() {
+	*x = MyIdentityProviderGetResp{}
+	mi := &file_mytenant_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *IdpInstanceGetResp) String() string {
+func (x *MyIdentityProviderGetResp) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*IdpInstanceGetResp) ProtoMessage() {}
+func (*MyIdentityProviderGetResp) ProtoMessage() {}
 
-func (x *IdpInstanceGetResp) ProtoReflect() protoreflect.Message {
-	mi := &file_mytenant_proto_msgTypes[14]
+func (x *MyIdentityProviderGetResp) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1142,113 +1208,101 @@ func (x *IdpInstanceGetResp) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use IdpInstanceGetResp.ProtoReflect.Descriptor instead.
-func (*IdpInstanceGetResp) Descriptor() ([]byte, []int) {
-	return file_mytenant_proto_rawDescGZIP(), []int{14}
+// Deprecated: Use MyIdentityProviderGetResp.ProtoReflect.Descriptor instead.
+func (*MyIdentityProviderGetResp) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{17}
 }
 
-func (x *IdpInstanceGetResp) GetKey() string {
+func (x *MyIdentityProviderGetResp) GetKey() string {
 	if x != nil {
 		return x.Key
 	}
 	return ""
 }
 
-func (x *IdpInstanceGetResp) GetDisplayName() string {
+func (x *MyIdentityProviderGetResp) GetDispName() string {
 	if x != nil {
-		return x.DisplayName
+		return x.DispName
 	}
 	return ""
 }
 
-func (x *IdpInstanceGetResp) GetProviderType() IdpProviderType {
+func (x *MyIdentityProviderGetResp) GetType() IdentityProviderDefs_Type {
 	if x != nil {
-		return x.ProviderType
+		return x.Type
 	}
-	return IdpProviderType_IdentityProviderUnspecified
+	return IdentityProviderDefs_IdentityProviderUnspecified
 }
 
-func (x *IdpInstanceGetResp) GetEnabled() bool {
+func (x *MyIdentityProviderGetResp) GetEnabled() bool {
 	if x != nil {
 		return x.Enabled
 	}
 	return false
 }
 
-func (x *IdpInstanceGetResp) GetDisplayOrder() int32 {
-	if x != nil {
-		return x.DisplayOrder
-	}
-	return 0
-}
-
-func (x *IdpInstanceGetResp) GetConfiguration() string {
-	if x != nil {
-		return x.Configuration
-	}
-	return ""
-}
-
-func (x *IdpInstanceGetResp) GetCreated() int64 {
+func (x *MyIdentityProviderGetResp) GetCreated() int64 {
 	if x != nil {
 		return x.Created
 	}
 	return 0
 }
 
-func (x *IdpInstanceGetResp) GetUpdated() int64 {
-	if x != nil {
-		return x.Updated
-	}
-	return 0
-}
-
-func (x *IdpInstanceGetResp) GetCreatedBy() string {
+func (x *MyIdentityProviderGetResp) GetCreatedBy() string {
 	if x != nil {
 		return x.CreatedBy
 	}
 	return ""
 }
 
-func (x *IdpInstanceGetResp) GetUpdatedBy() string {
+func (x *MyIdentityProviderGetResp) GetGoogle() *GoogleIDPConfig {
 	if x != nil {
-		return x.UpdatedBy
+		return x.Google
 	}
-	return ""
+	return nil
 }
 
-// Identity provider instance update request
-type IdpInstanceUpdateReq struct {
+func (x *MyIdentityProviderGetResp) GetMicrosoft() *MicrosoftIDPConfig {
+	if x != nil {
+		return x.Microsoft
+	}
+	return nil
+}
+
+// Identity provider update request
+type MyIdentityProviderUpdateReq struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Identity provider key
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// Display name
-	DisplayName string `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	DispName string `protobuf:"bytes,2,opt,name=dispName,proto3" json:"dispName,omitempty"`
 	// Whether configuration is enabled
 	Enabled bool `protobuf:"varint,3,opt,name=enabled,proto3" json:"enabled,omitempty"`
-	// Display order for UI
-	DisplayOrder int32 `protobuf:"varint,4,opt,name=display_order,json=displayOrder,proto3" json:"display_order,omitempty"`
-	// Provider configuration (including sensitive fields)
-	Configuration string `protobuf:"bytes,5,opt,name=configuration,proto3" json:"configuration,omitempty"`
+	// Provider type
+	Type IdentityProviderDefs_Type `protobuf:"varint,4,opt,name=type,proto3,enum=api.IdentityProviderDefs_Type" json:"type,omitempty"`
+	// configuration for Google Identity Provider
+	Google *GoogleIDPConfig `protobuf:"bytes,5,opt,name=google,proto3" json:"google,omitempty"`
+	// configuration for Microsoft Identity Provider
+	Microsoft     *MicrosoftIDPConfig `protobuf:"bytes,6,opt,name=microsoft,proto3" json:"microsoft,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *IdpInstanceUpdateReq) Reset() {
-	*x = IdpInstanceUpdateReq{}
-	mi := &file_mytenant_proto_msgTypes[15]
+func (x *MyIdentityProviderUpdateReq) Reset() {
+	*x = MyIdentityProviderUpdateReq{}
+	mi := &file_mytenant_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *IdpInstanceUpdateReq) String() string {
+func (x *MyIdentityProviderUpdateReq) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*IdpInstanceUpdateReq) ProtoMessage() {}
+func (*MyIdentityProviderUpdateReq) ProtoMessage() {}
 
-func (x *IdpInstanceUpdateReq) ProtoReflect() protoreflect.Message {
-	mi := &file_mytenant_proto_msgTypes[15]
+func (x *MyIdentityProviderUpdateReq) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1259,70 +1313,75 @@ func (x *IdpInstanceUpdateReq) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use IdpInstanceUpdateReq.ProtoReflect.Descriptor instead.
-func (*IdpInstanceUpdateReq) Descriptor() ([]byte, []int) {
-	return file_mytenant_proto_rawDescGZIP(), []int{15}
+// Deprecated: Use MyIdentityProviderUpdateReq.ProtoReflect.Descriptor instead.
+func (*MyIdentityProviderUpdateReq) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{18}
 }
 
-func (x *IdpInstanceUpdateReq) GetKey() string {
+func (x *MyIdentityProviderUpdateReq) GetKey() string {
 	if x != nil {
 		return x.Key
 	}
 	return ""
 }
 
-func (x *IdpInstanceUpdateReq) GetDisplayName() string {
+func (x *MyIdentityProviderUpdateReq) GetDispName() string {
 	if x != nil {
-		return x.DisplayName
+		return x.DispName
 	}
 	return ""
 }
 
-func (x *IdpInstanceUpdateReq) GetEnabled() bool {
+func (x *MyIdentityProviderUpdateReq) GetEnabled() bool {
 	if x != nil {
 		return x.Enabled
 	}
 	return false
 }
 
-func (x *IdpInstanceUpdateReq) GetDisplayOrder() int32 {
+func (x *MyIdentityProviderUpdateReq) GetType() IdentityProviderDefs_Type {
 	if x != nil {
-		return x.DisplayOrder
+		return x.Type
 	}
-	return 0
+	return IdentityProviderDefs_IdentityProviderUnspecified
 }
 
-func (x *IdpInstanceUpdateReq) GetConfiguration() string {
+func (x *MyIdentityProviderUpdateReq) GetGoogle() *GoogleIDPConfig {
 	if x != nil {
-		return x.Configuration
+		return x.Google
 	}
-	return ""
+	return nil
 }
 
-// Identity provider instance update response
-type IdpInstanceUpdateResp struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Success message
-	Message       string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+func (x *MyIdentityProviderUpdateReq) GetMicrosoft() *MicrosoftIDPConfig {
+	if x != nil {
+		return x.Microsoft
+	}
+	return nil
+}
+
+// Identity provider update response
+type MyIdentityProviderUpdateResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *IdpInstanceUpdateResp) Reset() {
-	*x = IdpInstanceUpdateResp{}
-	mi := &file_mytenant_proto_msgTypes[16]
+func (x *MyIdentityProviderUpdateResp) Reset() {
+	*x = MyIdentityProviderUpdateResp{}
+	mi := &file_mytenant_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *IdpInstanceUpdateResp) String() string {
+func (x *MyIdentityProviderUpdateResp) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*IdpInstanceUpdateResp) ProtoMessage() {}
+func (*MyIdentityProviderUpdateResp) ProtoMessage() {}
 
-func (x *IdpInstanceUpdateResp) ProtoReflect() protoreflect.Message {
-	mi := &file_mytenant_proto_msgTypes[16]
+func (x *MyIdentityProviderUpdateResp) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1333,20 +1392,13 @@ func (x *IdpInstanceUpdateResp) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use IdpInstanceUpdateResp.ProtoReflect.Descriptor instead.
-func (*IdpInstanceUpdateResp) Descriptor() ([]byte, []int) {
-	return file_mytenant_proto_rawDescGZIP(), []int{16}
+// Deprecated: Use MyIdentityProviderUpdateResp.ProtoReflect.Descriptor instead.
+func (*MyIdentityProviderUpdateResp) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{19}
 }
 
-func (x *IdpInstanceUpdateResp) GetMessage() string {
-	if x != nil {
-		return x.Message
-	}
-	return ""
-}
-
-// Identity provider instance delete request
-type IdpInstanceDeleteReq struct {
+// Identity provider delete request
+type MyIdentityProviderDeleteReq struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Identity provider key
 	Key           string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
@@ -1354,21 +1406,21 @@ type IdpInstanceDeleteReq struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *IdpInstanceDeleteReq) Reset() {
-	*x = IdpInstanceDeleteReq{}
-	mi := &file_mytenant_proto_msgTypes[17]
+func (x *MyIdentityProviderDeleteReq) Reset() {
+	*x = MyIdentityProviderDeleteReq{}
+	mi := &file_mytenant_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *IdpInstanceDeleteReq) String() string {
+func (x *MyIdentityProviderDeleteReq) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*IdpInstanceDeleteReq) ProtoMessage() {}
+func (*MyIdentityProviderDeleteReq) ProtoMessage() {}
 
-func (x *IdpInstanceDeleteReq) ProtoReflect() protoreflect.Message {
-	mi := &file_mytenant_proto_msgTypes[17]
+func (x *MyIdentityProviderDeleteReq) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1379,42 +1431,40 @@ func (x *IdpInstanceDeleteReq) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use IdpInstanceDeleteReq.ProtoReflect.Descriptor instead.
-func (*IdpInstanceDeleteReq) Descriptor() ([]byte, []int) {
-	return file_mytenant_proto_rawDescGZIP(), []int{17}
+// Deprecated: Use MyIdentityProviderDeleteReq.ProtoReflect.Descriptor instead.
+func (*MyIdentityProviderDeleteReq) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{20}
 }
 
-func (x *IdpInstanceDeleteReq) GetKey() string {
+func (x *MyIdentityProviderDeleteReq) GetKey() string {
 	if x != nil {
 		return x.Key
 	}
 	return ""
 }
 
-// Identity provider instance delete response
-type IdpInstanceDeleteResp struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Success message
-	Message       string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+// Identity provider delete response
+type MyIdentityProviderDeleteResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *IdpInstanceDeleteResp) Reset() {
-	*x = IdpInstanceDeleteResp{}
-	mi := &file_mytenant_proto_msgTypes[18]
+func (x *MyIdentityProviderDeleteResp) Reset() {
+	*x = MyIdentityProviderDeleteResp{}
+	mi := &file_mytenant_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *IdpInstanceDeleteResp) String() string {
+func (x *MyIdentityProviderDeleteResp) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*IdpInstanceDeleteResp) ProtoMessage() {}
+func (*MyIdentityProviderDeleteResp) ProtoMessage() {}
 
-func (x *IdpInstanceDeleteResp) ProtoReflect() protoreflect.Message {
-	mi := &file_mytenant_proto_msgTypes[18]
+func (x *MyIdentityProviderDeleteResp) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1425,16 +1475,9 @@ func (x *IdpInstanceDeleteResp) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use IdpInstanceDeleteResp.ProtoReflect.Descriptor instead.
-func (*IdpInstanceDeleteResp) Descriptor() ([]byte, []int) {
-	return file_mytenant_proto_rawDescGZIP(), []int{18}
-}
-
-func (x *IdpInstanceDeleteResp) GetMessage() string {
-	if x != nil {
-		return x.Message
-	}
-	return ""
+// Deprecated: Use MyIdentityProviderDeleteResp.ProtoReflect.Descriptor instead.
+func (*MyIdentityProviderDeleteResp) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{21}
 }
 
 var File_mytenant_proto protoreflect.FileDescriptor
@@ -1467,7 +1510,13 @@ const file_mytenant_proto_rawDesc = "" +
 	"\frecentlyUsed\x18\a \x01(\x05R\frecentlyUsed\x12 \n" +
 	"\vpasswordAge\x18\b \x01(\x05R\vpasswordAge\x12<\n" +
 	"\x19forceExpirePasswordChange\x18\t \x01(\x05R\x19forceExpirePasswordChange\"\x1c\n" +
-	"\x1aMyPasswordPolicyUpdateResp\"\xd9\x01\n" +
+	"\x1aMyPasswordPolicyUpdateResp\"Z\n" +
+	"\x14IdentityProviderDefs\"B\n" +
+	"\x04Type\x12\x1f\n" +
+	"\x1bIdentityProviderUnspecified\x10\x00\x12\n" +
+	"\n" +
+	"\x06Google\x10\x01\x12\r\n" +
+	"\tMicrosoft\x10\x02\"\xd9\x01\n" +
 	"\x0eIdpConfigField\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1a\n" +
@@ -1477,108 +1526,93 @@ const file_mytenant_proto_rawDesc = "" +
 	"\rdefault_value\x18\x06 \x01(\tR\fdefaultValue\x12\x1e\n" +
 	"\n" +
 	"validation\x18\a \x01(\tR\n" +
-	"validation\"\xc7\x02\n" +
-	"\x13IdpProviderMetadata\x129\n" +
-	"\rprovider_type\x18\x01 \x01(\x0e2\x14.api.IdpProviderTypeR\fproviderType\x12!\n" +
-	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12 \n" +
-	"\vdescription\x18\x03 \x01(\tR\vdescription\x128\n" +
-	"\rconfig_fields\x18\x04 \x03(\v2\x13.api.IdpConfigFieldR\fconfigFields\x12)\n" +
-	"\x10supported_scopes\x18\x05 \x03(\tR\x0fsupportedScopes\x12%\n" +
-	"\x0edefault_scopes\x18\x06 \x03(\tR\rdefaultScopes\x12$\n" +
-	"\rdocumentation\x18\a \x01(\tR\rdocumentation\"a\n" +
-	"\x0fIdpProvidersReq\x12=\n" +
-	"\fproviderType\x18\x01 \x01(\x0e2\x14.api.IdpProviderTypeH\x00R\fproviderType\x88\x01\x01B\x0f\n" +
-	"\r_providerType\"J\n" +
-	"\x10IdpProvidersResp\x126\n" +
-	"\tproviders\x18\x01 \x03(\v2\x18.api.IdpProviderMetadataR\tproviders\"\xeb\x01\n" +
-	"\x14IdpInstanceCreateReq\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12!\n" +
-	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x129\n" +
-	"\rprovider_type\x18\x03 \x01(\x0e2\x14.api.IdpProviderTypeR\fproviderType\x12\x18\n" +
-	"\aenabled\x18\x04 \x01(\bR\aenabled\x12#\n" +
-	"\rdisplay_order\x18\x05 \x01(\x05R\fdisplayOrder\x12$\n" +
-	"\rconfiguration\x18\x06 \x01(\tR\rconfiguration\"C\n" +
-	"\x15IdpInstanceCreateResp\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"\xde\x01\n" +
-	"\x12IdpInstanceListReq\x12>\n" +
-	"\rprovider_type\x18\x01 \x01(\x0e2\x14.api.IdpProviderTypeH\x00R\fproviderType\x88\x01\x01\x12\x1d\n" +
+	"validation\"\x1d\n" +
+	"\x1bIdentityProviderTypesGetReq\"4\n" +
+	"\x1eIdentityProviderTypesListEntry\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\"a\n" +
+	"\x1cIdentityProviderTypesGetResp\x12A\n" +
+	"\tproviders\x18\x01 \x03(\v2#.api.IdentityProviderTypesListEntryR\tproviders\"u\n" +
+	"\x0fGoogleIDPConfig\x12\x1a\n" +
+	"\bclientId\x18\x01 \x01(\tR\bclientId\x12\"\n" +
+	"\fclientSecret\x18\x02 \x01(\tR\fclientSecret\x12\"\n" +
+	"\fhostedDomain\x18\x03 \x01(\tR\fhostedDomain\"p\n" +
+	"\x12MicrosoftIDPConfig\x12\x1a\n" +
+	"\bclientId\x18\x01 \x01(\tR\bclientId\x12\"\n" +
+	"\fclientSecret\x18\x02 \x01(\tR\fclientSecret\x12\x1a\n" +
+	"\btenantId\x18\x03 \x01(\tR\btenantId\"\xfe\x01\n" +
+	"\x1bMyIdentityProviderCreateReq\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x1a\n" +
+	"\bdispName\x18\x02 \x01(\tR\bdispName\x122\n" +
+	"\x04type\x18\x03 \x01(\x0e2\x1e.api.IdentityProviderDefs.TypeR\x04type\x12\x18\n" +
+	"\aenabled\x18\x04 \x01(\bR\aenabled\x12,\n" +
+	"\x06google\x18\x05 \x01(\v2\x14.api.GoogleIDPConfigR\x06google\x125\n" +
+	"\tmicrosoft\x18\x06 \x01(\v2\x17.api.MicrosoftIDPConfigR\tmicrosoft\"\x1e\n" +
+	"\x1cMyIdentityProviderCreateResp\"\xd6\x01\n" +
+	"\x1aMyIdentityProvidersListReq\x127\n" +
+	"\x04type\x18\x01 \x01(\x0e2\x1e.api.IdentityProviderDefs.TypeH\x00R\x04type\x88\x01\x01\x12\x1d\n" +
 	"\aenabled\x18\x02 \x01(\bH\x01R\aenabled\x88\x01\x01\x12\x19\n" +
 	"\x05limit\x18\x03 \x01(\x05H\x02R\x05limit\x88\x01\x01\x12\x1b\n" +
-	"\x06offset\x18\x04 \x01(\x05H\x03R\x06offset\x88\x01\x01B\x10\n" +
-	"\x0e_provider_typeB\n" +
+	"\x06offset\x18\x04 \x01(\x05H\x03R\x06offset\x88\x01\x01B\a\n" +
+	"\x05_typeB\n" +
 	"\n" +
 	"\b_enabledB\b\n" +
 	"\x06_limitB\t\n" +
-	"\a_offset\"m\n" +
-	"\x13IdpInstanceListResp\x125\n" +
-	"\tinstances\x18\x01 \x03(\v2\x17.api.IdpInstanceSummaryR\tinstances\x12\x1f\n" +
-	"\vtotal_count\x18\x02 \x01(\x05R\n" +
-	"totalCount\"\xf7\x01\n" +
-	"\x12IdpInstanceSummary\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12!\n" +
-	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x129\n" +
-	"\rprovider_type\x18\x03 \x01(\x0e2\x14.api.IdpProviderTypeR\fproviderType\x12\x18\n" +
-	"\aenabled\x18\x04 \x01(\bR\aenabled\x12#\n" +
-	"\rdisplay_order\x18\x05 \x01(\x05R\fdisplayOrder\x12\x18\n" +
-	"\acreated\x18\x06 \x01(\x03R\acreated\x12\x18\n" +
-	"\aupdated\x18\a \x01(\x03R\aupdated\"%\n" +
-	"\x11IdpInstanceGetReq\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\"\xdb\x02\n" +
-	"\x12IdpInstanceGetResp\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12!\n" +
-	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x129\n" +
-	"\rprovider_type\x18\x03 \x01(\x0e2\x14.api.IdpProviderTypeR\fproviderType\x12\x18\n" +
-	"\aenabled\x18\x04 \x01(\bR\aenabled\x12#\n" +
-	"\rdisplay_order\x18\x05 \x01(\x05R\fdisplayOrder\x12$\n" +
-	"\rconfiguration\x18\x06 \x01(\tR\rconfiguration\x12\x18\n" +
-	"\acreated\x18\a \x01(\x03R\acreated\x12\x18\n" +
-	"\aupdated\x18\b \x01(\x03R\aupdated\x12\x1d\n" +
+	"\a_offset\"\xb4\x01\n" +
+	"\x1cMyIdentityProvidersListEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x1a\n" +
+	"\bdispName\x18\x02 \x01(\tR\bdispName\x122\n" +
+	"\x04type\x18\x03 \x01(\x0e2\x1e.api.IdentityProviderDefs.TypeR\x04type\x12\x18\n" +
+	"\aenabled\x18\x04 \x01(\bR\aenabled\x12\x18\n" +
+	"\acreated\x18\x05 \x01(\x03R\acreated\"l\n" +
+	"\x1bMyIdentityProvidersListResp\x12\x14\n" +
+	"\x05count\x18\x01 \x01(\x05R\x05count\x127\n" +
+	"\x05items\x18\x02 \x03(\v2!.api.MyIdentityProvidersListEntryR\x05items\",\n" +
+	"\x18MyIdentityProviderGetReq\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\"\xb5\x02\n" +
+	"\x19MyIdentityProviderGetResp\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x1a\n" +
+	"\bdispName\x18\x02 \x01(\tR\bdispName\x122\n" +
+	"\x04type\x18\x03 \x01(\x0e2\x1e.api.IdentityProviderDefs.TypeR\x04type\x12\x18\n" +
+	"\aenabled\x18\x04 \x01(\bR\aenabled\x12\x18\n" +
+	"\acreated\x18\x05 \x01(\x03R\acreated\x12\x1d\n" +
 	"\n" +
-	"created_by\x18\t \x01(\tR\tcreatedBy\x12\x1d\n" +
+	"created_by\x18\x06 \x01(\tR\tcreatedBy\x12,\n" +
+	"\x06google\x18\a \x01(\v2\x14.api.GoogleIDPConfigR\x06google\x125\n" +
+	"\tmicrosoft\x18\b \x01(\v2\x17.api.MicrosoftIDPConfigR\tmicrosoft\"\xfe\x01\n" +
+	"\x1bMyIdentityProviderUpdateReq\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x1a\n" +
+	"\bdispName\x18\x02 \x01(\tR\bdispName\x12\x18\n" +
+	"\aenabled\x18\x03 \x01(\bR\aenabled\x122\n" +
+	"\x04type\x18\x04 \x01(\x0e2\x1e.api.IdentityProviderDefs.TypeR\x04type\x12,\n" +
+	"\x06google\x18\x05 \x01(\v2\x14.api.GoogleIDPConfigR\x06google\x125\n" +
+	"\tmicrosoft\x18\x06 \x01(\v2\x17.api.MicrosoftIDPConfigR\tmicrosoft\"\x1e\n" +
+	"\x1cMyIdentityProviderUpdateResp\"/\n" +
+	"\x1bMyIdentityProviderDeleteReq\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\"\x1e\n" +
+	"\x1cMyIdentityProviderDeleteResp2\xbf\n" +
 	"\n" +
-	"updated_by\x18\n" +
-	" \x01(\tR\tupdatedBy\"\xb0\x01\n" +
-	"\x14IdpInstanceUpdateReq\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12!\n" +
-	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12\x18\n" +
-	"\aenabled\x18\x03 \x01(\bR\aenabled\x12#\n" +
-	"\rdisplay_order\x18\x04 \x01(\x05R\fdisplayOrder\x12$\n" +
-	"\rconfiguration\x18\x05 \x01(\tR\rconfiguration\"1\n" +
-	"\x15IdpInstanceUpdateResp\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessage\"(\n" +
-	"\x14IdpInstanceDeleteReq\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\"1\n" +
-	"\x15IdpInstanceDeleteResp\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessage*a\n" +
-	"\x0fIdpProviderType\x12\x1f\n" +
-	"\x1bIdentityProviderUnspecified\x10\x00\x12\n" +
-	"\n" +
-	"\x06Google\x10\x01\x12\r\n" +
-	"\tMicrosoft\x10\x02\x12\b\n" +
-	"\x04OIDC\x10\x03\x12\b\n" +
-	"\x04SAML\x10\x042\xf4\t\n" +
 	"\bMyTenant\x12\x94\x01\n" +
 	"\x13GetMyPasswordPolicy\x12\x1b.api.MyPasswordPolicyGetReq\x1a\x1c.api.MyPasswordPolicyGetResp\"B\x8a\xb5\x18\x16\n" +
 	"\x0fpassword-policy\x1a\x03get\x82\xd3\xe4\x93\x02\"\x12 /api/mytenant/v1/password-policy\x12\xa3\x01\n" +
 	"\x16UpdateMyPasswordPolicy\x12\x1e.api.MyPasswordPolicyUpdateReq\x1a\x1f.api.MyPasswordPolicyUpdateResp\"H\x8a\xb5\x18\x19\n" +
-	"\x0fpassword-policy\x1a\x06update\x82\xd3\xe4\x93\x02%:\x01*\x1a /api/mytenant/v1/password-policy\x12\x8f\x01\n" +
-	"\x18GetIdentityProviderTypes\x12\x14.api.IdpProvidersReq\x1a\x15.api.IdpProvidersResp\"F\x8a\xb5\x18\x12\n" +
+	"\x0fpassword-policy\x1a\x06update\x82\xd3\xe4\x93\x02%:\x01*\x1a /api/mytenant/v1/password-policy\x12\xaf\x01\n" +
+	"\x1aGetMyIdentityProviderTypes\x12 .api.IdentityProviderTypesGetReq\x1a!.api.IdentityProviderTypesGetResp\"L\x8a\xb5\x18\x18\n" +
 	"\n" +
-	"tenant-idp\x1a\x04list\x82\xd3\xe4\x93\x02*\x12(/api/mytenant/v1/identity-provider-types\x12\x9e\x01\n" +
-	"\x1eCreateIdentityProviderInstance\x12\x19.api.IdpInstanceCreateReq\x1a\x1a.api.IdpInstanceCreateResp\"E\x8a\xb5\x18\x14\n" +
+	"tenant-idp\x1a\n" +
+	"list-types\x82\xd3\xe4\x93\x02*\x12(/api/mytenant/v1/identity-provider-types\x12\xa6\x01\n" +
+	"\x18CreateMyIdentityProvider\x12 .api.MyIdentityProviderCreateReq\x1a!.api.MyIdentityProviderCreateResp\"E\x8a\xb5\x18\x14\n" +
 	"\n" +
-	"tenant-idp\x1a\x06create\x82\xd3\xe4\x93\x02':\x01*\"\"/api/mytenant/v1/identity-provider\x12\x94\x01\n" +
-	"\x1dListIdentityProviderInstances\x12\x17.api.IdpInstanceListReq\x1a\x18.api.IdpInstanceListResp\"@\x8a\xb5\x18\x12\n" +
+	"tenant-idp\x1a\x06create\x82\xd3\xe4\x93\x02':\x01*\"\"/api/mytenant/v1/identity-provider\x12\x9f\x01\n" +
+	"\x17ListMyIdentityProviders\x12\x1f.api.MyIdentityProvidersListReq\x1a .api.MyIdentityProvidersListResp\"A\x8a\xb5\x18\x12\n" +
 	"\n" +
-	"tenant-idp\x1a\x04list\x82\xd3\xe4\x93\x02$\x12\"/api/mytenant/v1/identity-provider\x12\x95\x01\n" +
-	"\x1bGetIdentityProviderInstance\x12\x16.api.IdpInstanceGetReq\x1a\x17.api.IdpInstanceGetResp\"E\x8a\xb5\x18\x11\n" +
+	"tenant-idp\x1a\x04list\x82\xd3\xe4\x93\x02%\x12#/api/mytenant/v1/identity-providers\x12\x9d\x01\n" +
+	"\x15GetMyIdentityProvider\x12\x1d.api.MyIdentityProviderGetReq\x1a\x1e.api.MyIdentityProviderGetResp\"E\x8a\xb5\x18\x11\n" +
 	"\n" +
-	"tenant-idp\x1a\x03get\x82\xd3\xe4\x93\x02*\x12(/api/mytenant/v1/identity-provider/{key}\x12\xa4\x01\n" +
-	"\x1eUpdateIdentityProviderInstance\x12\x19.api.IdpInstanceUpdateReq\x1a\x1a.api.IdpInstanceUpdateResp\"K\x8a\xb5\x18\x14\n" +
+	"tenant-idp\x1a\x03get\x82\xd3\xe4\x93\x02*\x12(/api/mytenant/v1/identity-provider/{key}\x12\xac\x01\n" +
+	"\x18UpdateMyIdentityProvider\x12 .api.MyIdentityProviderUpdateReq\x1a!.api.MyIdentityProviderUpdateResp\"K\x8a\xb5\x18\x14\n" +
 	"\n" +
-	"tenant-idp\x1a\x06update\x82\xd3\xe4\x93\x02-:\x01*\x1a(/api/mytenant/v1/identity-provider/{key}\x12\xa1\x01\n" +
-	"\x1eDeleteIdentityProviderInstance\x12\x19.api.IdpInstanceDeleteReq\x1a\x1a.api.IdpInstanceDeleteResp\"H\x8a\xb5\x18\x14\n" +
+	"tenant-idp\x1a\x06update\x82\xd3\xe4\x93\x02-:\x01*\x1a(/api/mytenant/v1/identity-provider/{key}\x12\xa9\x01\n" +
+	"\x18DeleteMyIdentityProvider\x12 .api.MyIdentityProviderDeleteReq\x1a!.api.MyIdentityProviderDeleteResp\"H\x8a\xb5\x18\x14\n" +
 	"\n" +
 	"tenant-idp\x1a\x06delete\x82\xd3\xe4\x93\x02**(/api/mytenant/v1/identity-provider/{key}B+Z)github.com/go-core-stack/auth-gateway/apib\x06proto3"
 
@@ -1595,60 +1629,67 @@ func file_mytenant_proto_rawDescGZIP() []byte {
 }
 
 var file_mytenant_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_mytenant_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
+var file_mytenant_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_mytenant_proto_goTypes = []any{
-	(IdpProviderType)(0),               // 0: api.IdpProviderType
-	(*MyPasswordPolicyGetReq)(nil),     // 1: api.MyPasswordPolicyGetReq
-	(*MyPasswordPolicyGetResp)(nil),    // 2: api.MyPasswordPolicyGetResp
-	(*MyPasswordPolicyUpdateReq)(nil),  // 3: api.MyPasswordPolicyUpdateReq
-	(*MyPasswordPolicyUpdateResp)(nil), // 4: api.MyPasswordPolicyUpdateResp
-	(*IdpConfigField)(nil),             // 5: api.IdpConfigField
-	(*IdpProviderMetadata)(nil),        // 6: api.IdpProviderMetadata
-	(*IdpProvidersReq)(nil),            // 7: api.IdpProvidersReq
-	(*IdpProvidersResp)(nil),           // 8: api.IdpProvidersResp
-	(*IdpInstanceCreateReq)(nil),       // 9: api.IdpInstanceCreateReq
-	(*IdpInstanceCreateResp)(nil),      // 10: api.IdpInstanceCreateResp
-	(*IdpInstanceListReq)(nil),         // 11: api.IdpInstanceListReq
-	(*IdpInstanceListResp)(nil),        // 12: api.IdpInstanceListResp
-	(*IdpInstanceSummary)(nil),         // 13: api.IdpInstanceSummary
-	(*IdpInstanceGetReq)(nil),          // 14: api.IdpInstanceGetReq
-	(*IdpInstanceGetResp)(nil),         // 15: api.IdpInstanceGetResp
-	(*IdpInstanceUpdateReq)(nil),       // 16: api.IdpInstanceUpdateReq
-	(*IdpInstanceUpdateResp)(nil),      // 17: api.IdpInstanceUpdateResp
-	(*IdpInstanceDeleteReq)(nil),       // 18: api.IdpInstanceDeleteReq
-	(*IdpInstanceDeleteResp)(nil),      // 19: api.IdpInstanceDeleteResp
+	(IdentityProviderDefs_Type)(0),         // 0: api.IdentityProviderDefs.Type
+	(*MyPasswordPolicyGetReq)(nil),         // 1: api.MyPasswordPolicyGetReq
+	(*MyPasswordPolicyGetResp)(nil),        // 2: api.MyPasswordPolicyGetResp
+	(*MyPasswordPolicyUpdateReq)(nil),      // 3: api.MyPasswordPolicyUpdateReq
+	(*MyPasswordPolicyUpdateResp)(nil),     // 4: api.MyPasswordPolicyUpdateResp
+	(*IdentityProviderDefs)(nil),           // 5: api.IdentityProviderDefs
+	(*IdpConfigField)(nil),                 // 6: api.IdpConfigField
+	(*IdentityProviderTypesGetReq)(nil),    // 7: api.IdentityProviderTypesGetReq
+	(*IdentityProviderTypesListEntry)(nil), // 8: api.IdentityProviderTypesListEntry
+	(*IdentityProviderTypesGetResp)(nil),   // 9: api.IdentityProviderTypesGetResp
+	(*GoogleIDPConfig)(nil),                // 10: api.GoogleIDPConfig
+	(*MicrosoftIDPConfig)(nil),             // 11: api.MicrosoftIDPConfig
+	(*MyIdentityProviderCreateReq)(nil),    // 12: api.MyIdentityProviderCreateReq
+	(*MyIdentityProviderCreateResp)(nil),   // 13: api.MyIdentityProviderCreateResp
+	(*MyIdentityProvidersListReq)(nil),     // 14: api.MyIdentityProvidersListReq
+	(*MyIdentityProvidersListEntry)(nil),   // 15: api.MyIdentityProvidersListEntry
+	(*MyIdentityProvidersListResp)(nil),    // 16: api.MyIdentityProvidersListResp
+	(*MyIdentityProviderGetReq)(nil),       // 17: api.MyIdentityProviderGetReq
+	(*MyIdentityProviderGetResp)(nil),      // 18: api.MyIdentityProviderGetResp
+	(*MyIdentityProviderUpdateReq)(nil),    // 19: api.MyIdentityProviderUpdateReq
+	(*MyIdentityProviderUpdateResp)(nil),   // 20: api.MyIdentityProviderUpdateResp
+	(*MyIdentityProviderDeleteReq)(nil),    // 21: api.MyIdentityProviderDeleteReq
+	(*MyIdentityProviderDeleteResp)(nil),   // 22: api.MyIdentityProviderDeleteResp
 }
 var file_mytenant_proto_depIdxs = []int32{
-	0,  // 0: api.IdpProviderMetadata.provider_type:type_name -> api.IdpProviderType
-	5,  // 1: api.IdpProviderMetadata.config_fields:type_name -> api.IdpConfigField
-	0,  // 2: api.IdpProvidersReq.providerType:type_name -> api.IdpProviderType
-	6,  // 3: api.IdpProvidersResp.providers:type_name -> api.IdpProviderMetadata
-	0,  // 4: api.IdpInstanceCreateReq.provider_type:type_name -> api.IdpProviderType
-	0,  // 5: api.IdpInstanceListReq.provider_type:type_name -> api.IdpProviderType
-	13, // 6: api.IdpInstanceListResp.instances:type_name -> api.IdpInstanceSummary
-	0,  // 7: api.IdpInstanceSummary.provider_type:type_name -> api.IdpProviderType
-	0,  // 8: api.IdpInstanceGetResp.provider_type:type_name -> api.IdpProviderType
-	1,  // 9: api.MyTenant.GetMyPasswordPolicy:input_type -> api.MyPasswordPolicyGetReq
-	3,  // 10: api.MyTenant.UpdateMyPasswordPolicy:input_type -> api.MyPasswordPolicyUpdateReq
-	7,  // 11: api.MyTenant.GetIdentityProviderTypes:input_type -> api.IdpProvidersReq
-	9,  // 12: api.MyTenant.CreateIdentityProviderInstance:input_type -> api.IdpInstanceCreateReq
-	11, // 13: api.MyTenant.ListIdentityProviderInstances:input_type -> api.IdpInstanceListReq
-	14, // 14: api.MyTenant.GetIdentityProviderInstance:input_type -> api.IdpInstanceGetReq
-	16, // 15: api.MyTenant.UpdateIdentityProviderInstance:input_type -> api.IdpInstanceUpdateReq
-	18, // 16: api.MyTenant.DeleteIdentityProviderInstance:input_type -> api.IdpInstanceDeleteReq
-	2,  // 17: api.MyTenant.GetMyPasswordPolicy:output_type -> api.MyPasswordPolicyGetResp
-	4,  // 18: api.MyTenant.UpdateMyPasswordPolicy:output_type -> api.MyPasswordPolicyUpdateResp
-	8,  // 19: api.MyTenant.GetIdentityProviderTypes:output_type -> api.IdpProvidersResp
-	10, // 20: api.MyTenant.CreateIdentityProviderInstance:output_type -> api.IdpInstanceCreateResp
-	12, // 21: api.MyTenant.ListIdentityProviderInstances:output_type -> api.IdpInstanceListResp
-	15, // 22: api.MyTenant.GetIdentityProviderInstance:output_type -> api.IdpInstanceGetResp
-	17, // 23: api.MyTenant.UpdateIdentityProviderInstance:output_type -> api.IdpInstanceUpdateResp
-	19, // 24: api.MyTenant.DeleteIdentityProviderInstance:output_type -> api.IdpInstanceDeleteResp
-	17, // [17:25] is the sub-list for method output_type
-	9,  // [9:17] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	8,  // 0: api.IdentityProviderTypesGetResp.providers:type_name -> api.IdentityProviderTypesListEntry
+	0,  // 1: api.MyIdentityProviderCreateReq.type:type_name -> api.IdentityProviderDefs.Type
+	10, // 2: api.MyIdentityProviderCreateReq.google:type_name -> api.GoogleIDPConfig
+	11, // 3: api.MyIdentityProviderCreateReq.microsoft:type_name -> api.MicrosoftIDPConfig
+	0,  // 4: api.MyIdentityProvidersListReq.type:type_name -> api.IdentityProviderDefs.Type
+	0,  // 5: api.MyIdentityProvidersListEntry.type:type_name -> api.IdentityProviderDefs.Type
+	15, // 6: api.MyIdentityProvidersListResp.items:type_name -> api.MyIdentityProvidersListEntry
+	0,  // 7: api.MyIdentityProviderGetResp.type:type_name -> api.IdentityProviderDefs.Type
+	10, // 8: api.MyIdentityProviderGetResp.google:type_name -> api.GoogleIDPConfig
+	11, // 9: api.MyIdentityProviderGetResp.microsoft:type_name -> api.MicrosoftIDPConfig
+	0,  // 10: api.MyIdentityProviderUpdateReq.type:type_name -> api.IdentityProviderDefs.Type
+	10, // 11: api.MyIdentityProviderUpdateReq.google:type_name -> api.GoogleIDPConfig
+	11, // 12: api.MyIdentityProviderUpdateReq.microsoft:type_name -> api.MicrosoftIDPConfig
+	1,  // 13: api.MyTenant.GetMyPasswordPolicy:input_type -> api.MyPasswordPolicyGetReq
+	3,  // 14: api.MyTenant.UpdateMyPasswordPolicy:input_type -> api.MyPasswordPolicyUpdateReq
+	7,  // 15: api.MyTenant.GetMyIdentityProviderTypes:input_type -> api.IdentityProviderTypesGetReq
+	12, // 16: api.MyTenant.CreateMyIdentityProvider:input_type -> api.MyIdentityProviderCreateReq
+	14, // 17: api.MyTenant.ListMyIdentityProviders:input_type -> api.MyIdentityProvidersListReq
+	17, // 18: api.MyTenant.GetMyIdentityProvider:input_type -> api.MyIdentityProviderGetReq
+	19, // 19: api.MyTenant.UpdateMyIdentityProvider:input_type -> api.MyIdentityProviderUpdateReq
+	21, // 20: api.MyTenant.DeleteMyIdentityProvider:input_type -> api.MyIdentityProviderDeleteReq
+	2,  // 21: api.MyTenant.GetMyPasswordPolicy:output_type -> api.MyPasswordPolicyGetResp
+	4,  // 22: api.MyTenant.UpdateMyPasswordPolicy:output_type -> api.MyPasswordPolicyUpdateResp
+	9,  // 23: api.MyTenant.GetMyIdentityProviderTypes:output_type -> api.IdentityProviderTypesGetResp
+	13, // 24: api.MyTenant.CreateMyIdentityProvider:output_type -> api.MyIdentityProviderCreateResp
+	16, // 25: api.MyTenant.ListMyIdentityProviders:output_type -> api.MyIdentityProvidersListResp
+	18, // 26: api.MyTenant.GetMyIdentityProvider:output_type -> api.MyIdentityProviderGetResp
+	20, // 27: api.MyTenant.UpdateMyIdentityProvider:output_type -> api.MyIdentityProviderUpdateResp
+	22, // 28: api.MyTenant.DeleteMyIdentityProvider:output_type -> api.MyIdentityProviderDeleteResp
+	21, // [21:29] is the sub-list for method output_type
+	13, // [13:21] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_mytenant_proto_init() }
@@ -1656,15 +1697,14 @@ func file_mytenant_proto_init() {
 	if File_mytenant_proto != nil {
 		return
 	}
-	file_mytenant_proto_msgTypes[6].OneofWrappers = []any{}
-	file_mytenant_proto_msgTypes[10].OneofWrappers = []any{}
+	file_mytenant_proto_msgTypes[13].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_mytenant_proto_rawDesc), len(file_mytenant_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   19,
+			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/mytenant.pb.go
+++ b/api/mytenant.pb.go
@@ -26,6 +26,62 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Identity Provider types
+type IdpProviderType int32
+
+const (
+	IdpProviderType_IdentityProviderUnspecified IdpProviderType = 0
+	IdpProviderType_Google                      IdpProviderType = 1
+	IdpProviderType_Microsoft                   IdpProviderType = 2
+	IdpProviderType_OIDC                        IdpProviderType = 3
+	IdpProviderType_SAML                        IdpProviderType = 4
+)
+
+// Enum value maps for IdpProviderType.
+var (
+	IdpProviderType_name = map[int32]string{
+		0: "IdentityProviderUnspecified",
+		1: "Google",
+		2: "Microsoft",
+		3: "OIDC",
+		4: "SAML",
+	}
+	IdpProviderType_value = map[string]int32{
+		"IdentityProviderUnspecified": 0,
+		"Google":                      1,
+		"Microsoft":                   2,
+		"OIDC":                        3,
+		"SAML":                        4,
+	}
+)
+
+func (x IdpProviderType) Enum() *IdpProviderType {
+	p := new(IdpProviderType)
+	*p = x
+	return p
+}
+
+func (x IdpProviderType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (IdpProviderType) Descriptor() protoreflect.EnumDescriptor {
+	return file_mytenant_proto_enumTypes[0].Descriptor()
+}
+
+func (IdpProviderType) Type() protoreflect.EnumType {
+	return &file_mytenant_proto_enumTypes[0]
+}
+
+func (x IdpProviderType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use IdpProviderType.Descriptor instead.
+func (IdpProviderType) EnumDescriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{0}
+}
+
 // password policy get request
 type MyPasswordPolicyGetReq struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -336,6 +392,1051 @@ func (*MyPasswordPolicyUpdateResp) Descriptor() ([]byte, []int) {
 	return file_mytenant_proto_rawDescGZIP(), []int{3}
 }
 
+// Configuration field metadata for validation
+type IdpConfigField struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Type          string                 `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Required      bool                   `protobuf:"varint,3,opt,name=required,proto3" json:"required,omitempty"`
+	Sensitive     bool                   `protobuf:"varint,4,opt,name=sensitive,proto3" json:"sensitive,omitempty"`
+	Description   string                 `protobuf:"bytes,5,opt,name=description,proto3" json:"description,omitempty"`
+	DefaultValue  string                 `protobuf:"bytes,6,opt,name=default_value,json=defaultValue,proto3" json:"default_value,omitempty"`
+	Validation    string                 `protobuf:"bytes,7,opt,name=validation,proto3" json:"validation,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdpConfigField) Reset() {
+	*x = IdpConfigField{}
+	mi := &file_mytenant_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpConfigField) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpConfigField) ProtoMessage() {}
+
+func (x *IdpConfigField) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpConfigField.ProtoReflect.Descriptor instead.
+func (*IdpConfigField) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *IdpConfigField) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *IdpConfigField) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *IdpConfigField) GetRequired() bool {
+	if x != nil {
+		return x.Required
+	}
+	return false
+}
+
+func (x *IdpConfigField) GetSensitive() bool {
+	if x != nil {
+		return x.Sensitive
+	}
+	return false
+}
+
+func (x *IdpConfigField) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *IdpConfigField) GetDefaultValue() string {
+	if x != nil {
+		return x.DefaultValue
+	}
+	return ""
+}
+
+func (x *IdpConfigField) GetValidation() string {
+	if x != nil {
+		return x.Validation
+	}
+	return ""
+}
+
+// Provider metadata
+type IdpProviderMetadata struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	ProviderType    IdpProviderType        `protobuf:"varint,1,opt,name=provider_type,json=providerType,proto3,enum=api.IdpProviderType" json:"provider_type,omitempty"`
+	DisplayName     string                 `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	Description     string                 `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	ConfigFields    []*IdpConfigField      `protobuf:"bytes,4,rep,name=config_fields,json=configFields,proto3" json:"config_fields,omitempty"`
+	SupportedScopes []string               `protobuf:"bytes,5,rep,name=supported_scopes,json=supportedScopes,proto3" json:"supported_scopes,omitempty"`
+	DefaultScopes   []string               `protobuf:"bytes,6,rep,name=default_scopes,json=defaultScopes,proto3" json:"default_scopes,omitempty"`
+	Documentation   string                 `protobuf:"bytes,7,opt,name=documentation,proto3" json:"documentation,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *IdpProviderMetadata) Reset() {
+	*x = IdpProviderMetadata{}
+	mi := &file_mytenant_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpProviderMetadata) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpProviderMetadata) ProtoMessage() {}
+
+func (x *IdpProviderMetadata) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpProviderMetadata.ProtoReflect.Descriptor instead.
+func (*IdpProviderMetadata) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *IdpProviderMetadata) GetProviderType() IdpProviderType {
+	if x != nil {
+		return x.ProviderType
+	}
+	return IdpProviderType_IdentityProviderUnspecified
+}
+
+func (x *IdpProviderMetadata) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *IdpProviderMetadata) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *IdpProviderMetadata) GetConfigFields() []*IdpConfigField {
+	if x != nil {
+		return x.ConfigFields
+	}
+	return nil
+}
+
+func (x *IdpProviderMetadata) GetSupportedScopes() []string {
+	if x != nil {
+		return x.SupportedScopes
+	}
+	return nil
+}
+
+func (x *IdpProviderMetadata) GetDefaultScopes() []string {
+	if x != nil {
+		return x.DefaultScopes
+	}
+	return nil
+}
+
+func (x *IdpProviderMetadata) GetDocumentation() string {
+	if x != nil {
+		return x.Documentation
+	}
+	return ""
+}
+
+// Identity provider providers request (list supported provider types)
+type IdpProvidersReq struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Optional filter by provider type
+	ProviderType  *IdpProviderType `protobuf:"varint,1,opt,name=providerType,proto3,enum=api.IdpProviderType,oneof" json:"providerType,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdpProvidersReq) Reset() {
+	*x = IdpProvidersReq{}
+	mi := &file_mytenant_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpProvidersReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpProvidersReq) ProtoMessage() {}
+
+func (x *IdpProvidersReq) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpProvidersReq.ProtoReflect.Descriptor instead.
+func (*IdpProvidersReq) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *IdpProvidersReq) GetProviderType() IdpProviderType {
+	if x != nil && x.ProviderType != nil {
+		return *x.ProviderType
+	}
+	return IdpProviderType_IdentityProviderUnspecified
+}
+
+// Identity provider providers response
+type IdpProvidersResp struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Available provider types and their metadata
+	Providers     []*IdpProviderMetadata `protobuf:"bytes,1,rep,name=providers,proto3" json:"providers,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdpProvidersResp) Reset() {
+	*x = IdpProvidersResp{}
+	mi := &file_mytenant_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpProvidersResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpProvidersResp) ProtoMessage() {}
+
+func (x *IdpProvidersResp) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpProvidersResp.ProtoReflect.Descriptor instead.
+func (*IdpProvidersResp) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *IdpProvidersResp) GetProviders() []*IdpProviderMetadata {
+	if x != nil {
+		return x.Providers
+	}
+	return nil
+}
+
+// Identity provider instance create request
+type IdpInstanceCreateReq struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Identity provider key (unique per tenant)
+	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// Display name
+	DisplayName string `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	// Provider type
+	ProviderType IdpProviderType `protobuf:"varint,3,opt,name=provider_type,json=providerType,proto3,enum=api.IdpProviderType" json:"provider_type,omitempty"`
+	// Whether configuration is enabled
+	Enabled bool `protobuf:"varint,4,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	// Display order for UI
+	DisplayOrder int32 `protobuf:"varint,5,opt,name=display_order,json=displayOrder,proto3" json:"display_order,omitempty"`
+	// Provider configuration (including sensitive fields)
+	Configuration string `protobuf:"bytes,6,opt,name=configuration,proto3" json:"configuration,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdpInstanceCreateReq) Reset() {
+	*x = IdpInstanceCreateReq{}
+	mi := &file_mytenant_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpInstanceCreateReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpInstanceCreateReq) ProtoMessage() {}
+
+func (x *IdpInstanceCreateReq) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpInstanceCreateReq.ProtoReflect.Descriptor instead.
+func (*IdpInstanceCreateReq) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *IdpInstanceCreateReq) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *IdpInstanceCreateReq) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *IdpInstanceCreateReq) GetProviderType() IdpProviderType {
+	if x != nil {
+		return x.ProviderType
+	}
+	return IdpProviderType_IdentityProviderUnspecified
+}
+
+func (x *IdpInstanceCreateReq) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *IdpInstanceCreateReq) GetDisplayOrder() int32 {
+	if x != nil {
+		return x.DisplayOrder
+	}
+	return 0
+}
+
+func (x *IdpInstanceCreateReq) GetConfiguration() string {
+	if x != nil {
+		return x.Configuration
+	}
+	return ""
+}
+
+// Identity provider instance create response
+type IdpInstanceCreateResp struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Created identity provider key
+	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// Success message
+	Message       string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdpInstanceCreateResp) Reset() {
+	*x = IdpInstanceCreateResp{}
+	mi := &file_mytenant_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpInstanceCreateResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpInstanceCreateResp) ProtoMessage() {}
+
+func (x *IdpInstanceCreateResp) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpInstanceCreateResp.ProtoReflect.Descriptor instead.
+func (*IdpInstanceCreateResp) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *IdpInstanceCreateResp) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *IdpInstanceCreateResp) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+// Identity provider instance list request
+type IdpInstanceListReq struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Optional filter by provider type
+	ProviderType *IdpProviderType `protobuf:"varint,1,opt,name=provider_type,json=providerType,proto3,enum=api.IdpProviderType,oneof" json:"provider_type,omitempty"`
+	// Optional filter by enabled status
+	Enabled *bool `protobuf:"varint,2,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
+	// Optional pagination limit
+	Limit *int32 `protobuf:"varint,3,opt,name=limit,proto3,oneof" json:"limit,omitempty"`
+	// Optional pagination offset
+	Offset        *int32 `protobuf:"varint,4,opt,name=offset,proto3,oneof" json:"offset,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdpInstanceListReq) Reset() {
+	*x = IdpInstanceListReq{}
+	mi := &file_mytenant_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpInstanceListReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpInstanceListReq) ProtoMessage() {}
+
+func (x *IdpInstanceListReq) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpInstanceListReq.ProtoReflect.Descriptor instead.
+func (*IdpInstanceListReq) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *IdpInstanceListReq) GetProviderType() IdpProviderType {
+	if x != nil && x.ProviderType != nil {
+		return *x.ProviderType
+	}
+	return IdpProviderType_IdentityProviderUnspecified
+}
+
+func (x *IdpInstanceListReq) GetEnabled() bool {
+	if x != nil && x.Enabled != nil {
+		return *x.Enabled
+	}
+	return false
+}
+
+func (x *IdpInstanceListReq) GetLimit() int32 {
+	if x != nil && x.Limit != nil {
+		return *x.Limit
+	}
+	return 0
+}
+
+func (x *IdpInstanceListReq) GetOffset() int32 {
+	if x != nil && x.Offset != nil {
+		return *x.Offset
+	}
+	return 0
+}
+
+// Identity provider instance list response
+type IdpInstanceListResp struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// List of identity provider instances
+	Instances []*IdpInstanceSummary `protobuf:"bytes,1,rep,name=instances,proto3" json:"instances,omitempty"`
+	// Total count of instances (for pagination)
+	TotalCount    int32 `protobuf:"varint,2,opt,name=total_count,json=totalCount,proto3" json:"total_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdpInstanceListResp) Reset() {
+	*x = IdpInstanceListResp{}
+	mi := &file_mytenant_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpInstanceListResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpInstanceListResp) ProtoMessage() {}
+
+func (x *IdpInstanceListResp) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpInstanceListResp.ProtoReflect.Descriptor instead.
+func (*IdpInstanceListResp) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *IdpInstanceListResp) GetInstances() []*IdpInstanceSummary {
+	if x != nil {
+		return x.Instances
+	}
+	return nil
+}
+
+func (x *IdpInstanceListResp) GetTotalCount() int32 {
+	if x != nil {
+		return x.TotalCount
+	}
+	return 0
+}
+
+// Identity provider instance summary (for list responses)
+type IdpInstanceSummary struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Identity provider key
+	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// Display name
+	DisplayName string `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	// Provider type
+	ProviderType IdpProviderType `protobuf:"varint,3,opt,name=provider_type,json=providerType,proto3,enum=api.IdpProviderType" json:"provider_type,omitempty"`
+	// Whether configuration is enabled
+	Enabled bool `protobuf:"varint,4,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	// Display order for UI
+	DisplayOrder int32 `protobuf:"varint,5,opt,name=display_order,json=displayOrder,proto3" json:"display_order,omitempty"`
+	// Created timestamp
+	Created int64 `protobuf:"varint,6,opt,name=created,proto3" json:"created,omitempty"`
+	// Updated timestamp
+	Updated       int64 `protobuf:"varint,7,opt,name=updated,proto3" json:"updated,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdpInstanceSummary) Reset() {
+	*x = IdpInstanceSummary{}
+	mi := &file_mytenant_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpInstanceSummary) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpInstanceSummary) ProtoMessage() {}
+
+func (x *IdpInstanceSummary) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpInstanceSummary.ProtoReflect.Descriptor instead.
+func (*IdpInstanceSummary) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *IdpInstanceSummary) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *IdpInstanceSummary) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *IdpInstanceSummary) GetProviderType() IdpProviderType {
+	if x != nil {
+		return x.ProviderType
+	}
+	return IdpProviderType_IdentityProviderUnspecified
+}
+
+func (x *IdpInstanceSummary) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *IdpInstanceSummary) GetDisplayOrder() int32 {
+	if x != nil {
+		return x.DisplayOrder
+	}
+	return 0
+}
+
+func (x *IdpInstanceSummary) GetCreated() int64 {
+	if x != nil {
+		return x.Created
+	}
+	return 0
+}
+
+func (x *IdpInstanceSummary) GetUpdated() int64 {
+	if x != nil {
+		return x.Updated
+	}
+	return 0
+}
+
+// Identity provider instance get request
+type IdpInstanceGetReq struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Identity provider key
+	Key           string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdpInstanceGetReq) Reset() {
+	*x = IdpInstanceGetReq{}
+	mi := &file_mytenant_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpInstanceGetReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpInstanceGetReq) ProtoMessage() {}
+
+func (x *IdpInstanceGetReq) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpInstanceGetReq.ProtoReflect.Descriptor instead.
+func (*IdpInstanceGetReq) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *IdpInstanceGetReq) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+// Identity provider instance get response
+type IdpInstanceGetResp struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Identity provider key
+	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// Display name
+	DisplayName string `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	// Provider type
+	ProviderType IdpProviderType `protobuf:"varint,3,opt,name=provider_type,json=providerType,proto3,enum=api.IdpProviderType" json:"provider_type,omitempty"`
+	// Whether configuration is enabled
+	Enabled bool `protobuf:"varint,4,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	// Display order for UI
+	DisplayOrder int32 `protobuf:"varint,5,opt,name=display_order,json=displayOrder,proto3" json:"display_order,omitempty"`
+	// Provider configuration (non-sensitive fields only)
+	Configuration string `protobuf:"bytes,6,opt,name=configuration,proto3" json:"configuration,omitempty"`
+	// Created timestamp
+	Created int64 `protobuf:"varint,7,opt,name=created,proto3" json:"created,omitempty"`
+	// Updated timestamp
+	Updated int64 `protobuf:"varint,8,opt,name=updated,proto3" json:"updated,omitempty"`
+	// Created by user
+	CreatedBy string `protobuf:"bytes,9,opt,name=created_by,json=createdBy,proto3" json:"created_by,omitempty"`
+	// Updated by user
+	UpdatedBy     string `protobuf:"bytes,10,opt,name=updated_by,json=updatedBy,proto3" json:"updated_by,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdpInstanceGetResp) Reset() {
+	*x = IdpInstanceGetResp{}
+	mi := &file_mytenant_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpInstanceGetResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpInstanceGetResp) ProtoMessage() {}
+
+func (x *IdpInstanceGetResp) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpInstanceGetResp.ProtoReflect.Descriptor instead.
+func (*IdpInstanceGetResp) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *IdpInstanceGetResp) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *IdpInstanceGetResp) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *IdpInstanceGetResp) GetProviderType() IdpProviderType {
+	if x != nil {
+		return x.ProviderType
+	}
+	return IdpProviderType_IdentityProviderUnspecified
+}
+
+func (x *IdpInstanceGetResp) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *IdpInstanceGetResp) GetDisplayOrder() int32 {
+	if x != nil {
+		return x.DisplayOrder
+	}
+	return 0
+}
+
+func (x *IdpInstanceGetResp) GetConfiguration() string {
+	if x != nil {
+		return x.Configuration
+	}
+	return ""
+}
+
+func (x *IdpInstanceGetResp) GetCreated() int64 {
+	if x != nil {
+		return x.Created
+	}
+	return 0
+}
+
+func (x *IdpInstanceGetResp) GetUpdated() int64 {
+	if x != nil {
+		return x.Updated
+	}
+	return 0
+}
+
+func (x *IdpInstanceGetResp) GetCreatedBy() string {
+	if x != nil {
+		return x.CreatedBy
+	}
+	return ""
+}
+
+func (x *IdpInstanceGetResp) GetUpdatedBy() string {
+	if x != nil {
+		return x.UpdatedBy
+	}
+	return ""
+}
+
+// Identity provider instance update request
+type IdpInstanceUpdateReq struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Identity provider key
+	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// Display name
+	DisplayName string `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	// Whether configuration is enabled
+	Enabled bool `protobuf:"varint,3,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	// Display order for UI
+	DisplayOrder int32 `protobuf:"varint,4,opt,name=display_order,json=displayOrder,proto3" json:"display_order,omitempty"`
+	// Provider configuration (including sensitive fields)
+	Configuration string `protobuf:"bytes,5,opt,name=configuration,proto3" json:"configuration,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdpInstanceUpdateReq) Reset() {
+	*x = IdpInstanceUpdateReq{}
+	mi := &file_mytenant_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpInstanceUpdateReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpInstanceUpdateReq) ProtoMessage() {}
+
+func (x *IdpInstanceUpdateReq) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpInstanceUpdateReq.ProtoReflect.Descriptor instead.
+func (*IdpInstanceUpdateReq) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *IdpInstanceUpdateReq) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *IdpInstanceUpdateReq) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *IdpInstanceUpdateReq) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *IdpInstanceUpdateReq) GetDisplayOrder() int32 {
+	if x != nil {
+		return x.DisplayOrder
+	}
+	return 0
+}
+
+func (x *IdpInstanceUpdateReq) GetConfiguration() string {
+	if x != nil {
+		return x.Configuration
+	}
+	return ""
+}
+
+// Identity provider instance update response
+type IdpInstanceUpdateResp struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Success message
+	Message       string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdpInstanceUpdateResp) Reset() {
+	*x = IdpInstanceUpdateResp{}
+	mi := &file_mytenant_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpInstanceUpdateResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpInstanceUpdateResp) ProtoMessage() {}
+
+func (x *IdpInstanceUpdateResp) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpInstanceUpdateResp.ProtoReflect.Descriptor instead.
+func (*IdpInstanceUpdateResp) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *IdpInstanceUpdateResp) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+// Identity provider instance delete request
+type IdpInstanceDeleteReq struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Identity provider key
+	Key           string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdpInstanceDeleteReq) Reset() {
+	*x = IdpInstanceDeleteReq{}
+	mi := &file_mytenant_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpInstanceDeleteReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpInstanceDeleteReq) ProtoMessage() {}
+
+func (x *IdpInstanceDeleteReq) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpInstanceDeleteReq.ProtoReflect.Descriptor instead.
+func (*IdpInstanceDeleteReq) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *IdpInstanceDeleteReq) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+// Identity provider instance delete response
+type IdpInstanceDeleteResp struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Success message
+	Message       string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IdpInstanceDeleteResp) Reset() {
+	*x = IdpInstanceDeleteResp{}
+	mi := &file_mytenant_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IdpInstanceDeleteResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IdpInstanceDeleteResp) ProtoMessage() {}
+
+func (x *IdpInstanceDeleteResp) ProtoReflect() protoreflect.Message {
+	mi := &file_mytenant_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IdpInstanceDeleteResp.ProtoReflect.Descriptor instead.
+func (*IdpInstanceDeleteResp) Descriptor() ([]byte, []int) {
+	return file_mytenant_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *IdpInstanceDeleteResp) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 var File_mytenant_proto protoreflect.FileDescriptor
 
 const file_mytenant_proto_rawDesc = "" +
@@ -366,12 +1467,120 @@ const file_mytenant_proto_rawDesc = "" +
 	"\frecentlyUsed\x18\a \x01(\x05R\frecentlyUsed\x12 \n" +
 	"\vpasswordAge\x18\b \x01(\x05R\vpasswordAge\x12<\n" +
 	"\x19forceExpirePasswordChange\x18\t \x01(\x05R\x19forceExpirePasswordChange\"\x1c\n" +
-	"\x1aMyPasswordPolicyUpdateResp2\xc7\x02\n" +
+	"\x1aMyPasswordPolicyUpdateResp\"\xd9\x01\n" +
+	"\x0eIdpConfigField\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
+	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1a\n" +
+	"\brequired\x18\x03 \x01(\bR\brequired\x12\x1c\n" +
+	"\tsensitive\x18\x04 \x01(\bR\tsensitive\x12 \n" +
+	"\vdescription\x18\x05 \x01(\tR\vdescription\x12#\n" +
+	"\rdefault_value\x18\x06 \x01(\tR\fdefaultValue\x12\x1e\n" +
+	"\n" +
+	"validation\x18\a \x01(\tR\n" +
+	"validation\"\xc7\x02\n" +
+	"\x13IdpProviderMetadata\x129\n" +
+	"\rprovider_type\x18\x01 \x01(\x0e2\x14.api.IdpProviderTypeR\fproviderType\x12!\n" +
+	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12 \n" +
+	"\vdescription\x18\x03 \x01(\tR\vdescription\x128\n" +
+	"\rconfig_fields\x18\x04 \x03(\v2\x13.api.IdpConfigFieldR\fconfigFields\x12)\n" +
+	"\x10supported_scopes\x18\x05 \x03(\tR\x0fsupportedScopes\x12%\n" +
+	"\x0edefault_scopes\x18\x06 \x03(\tR\rdefaultScopes\x12$\n" +
+	"\rdocumentation\x18\a \x01(\tR\rdocumentation\"a\n" +
+	"\x0fIdpProvidersReq\x12=\n" +
+	"\fproviderType\x18\x01 \x01(\x0e2\x14.api.IdpProviderTypeH\x00R\fproviderType\x88\x01\x01B\x0f\n" +
+	"\r_providerType\"J\n" +
+	"\x10IdpProvidersResp\x126\n" +
+	"\tproviders\x18\x01 \x03(\v2\x18.api.IdpProviderMetadataR\tproviders\"\xeb\x01\n" +
+	"\x14IdpInstanceCreateReq\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12!\n" +
+	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x129\n" +
+	"\rprovider_type\x18\x03 \x01(\x0e2\x14.api.IdpProviderTypeR\fproviderType\x12\x18\n" +
+	"\aenabled\x18\x04 \x01(\bR\aenabled\x12#\n" +
+	"\rdisplay_order\x18\x05 \x01(\x05R\fdisplayOrder\x12$\n" +
+	"\rconfiguration\x18\x06 \x01(\tR\rconfiguration\"C\n" +
+	"\x15IdpInstanceCreateResp\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"\xde\x01\n" +
+	"\x12IdpInstanceListReq\x12>\n" +
+	"\rprovider_type\x18\x01 \x01(\x0e2\x14.api.IdpProviderTypeH\x00R\fproviderType\x88\x01\x01\x12\x1d\n" +
+	"\aenabled\x18\x02 \x01(\bH\x01R\aenabled\x88\x01\x01\x12\x19\n" +
+	"\x05limit\x18\x03 \x01(\x05H\x02R\x05limit\x88\x01\x01\x12\x1b\n" +
+	"\x06offset\x18\x04 \x01(\x05H\x03R\x06offset\x88\x01\x01B\x10\n" +
+	"\x0e_provider_typeB\n" +
+	"\n" +
+	"\b_enabledB\b\n" +
+	"\x06_limitB\t\n" +
+	"\a_offset\"m\n" +
+	"\x13IdpInstanceListResp\x125\n" +
+	"\tinstances\x18\x01 \x03(\v2\x17.api.IdpInstanceSummaryR\tinstances\x12\x1f\n" +
+	"\vtotal_count\x18\x02 \x01(\x05R\n" +
+	"totalCount\"\xf7\x01\n" +
+	"\x12IdpInstanceSummary\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12!\n" +
+	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x129\n" +
+	"\rprovider_type\x18\x03 \x01(\x0e2\x14.api.IdpProviderTypeR\fproviderType\x12\x18\n" +
+	"\aenabled\x18\x04 \x01(\bR\aenabled\x12#\n" +
+	"\rdisplay_order\x18\x05 \x01(\x05R\fdisplayOrder\x12\x18\n" +
+	"\acreated\x18\x06 \x01(\x03R\acreated\x12\x18\n" +
+	"\aupdated\x18\a \x01(\x03R\aupdated\"%\n" +
+	"\x11IdpInstanceGetReq\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\"\xdb\x02\n" +
+	"\x12IdpInstanceGetResp\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12!\n" +
+	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x129\n" +
+	"\rprovider_type\x18\x03 \x01(\x0e2\x14.api.IdpProviderTypeR\fproviderType\x12\x18\n" +
+	"\aenabled\x18\x04 \x01(\bR\aenabled\x12#\n" +
+	"\rdisplay_order\x18\x05 \x01(\x05R\fdisplayOrder\x12$\n" +
+	"\rconfiguration\x18\x06 \x01(\tR\rconfiguration\x12\x18\n" +
+	"\acreated\x18\a \x01(\x03R\acreated\x12\x18\n" +
+	"\aupdated\x18\b \x01(\x03R\aupdated\x12\x1d\n" +
+	"\n" +
+	"created_by\x18\t \x01(\tR\tcreatedBy\x12\x1d\n" +
+	"\n" +
+	"updated_by\x18\n" +
+	" \x01(\tR\tupdatedBy\"\xb0\x01\n" +
+	"\x14IdpInstanceUpdateReq\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12!\n" +
+	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12\x18\n" +
+	"\aenabled\x18\x03 \x01(\bR\aenabled\x12#\n" +
+	"\rdisplay_order\x18\x04 \x01(\x05R\fdisplayOrder\x12$\n" +
+	"\rconfiguration\x18\x05 \x01(\tR\rconfiguration\"1\n" +
+	"\x15IdpInstanceUpdateResp\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\"(\n" +
+	"\x14IdpInstanceDeleteReq\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\"1\n" +
+	"\x15IdpInstanceDeleteResp\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage*a\n" +
+	"\x0fIdpProviderType\x12\x1f\n" +
+	"\x1bIdentityProviderUnspecified\x10\x00\x12\n" +
+	"\n" +
+	"\x06Google\x10\x01\x12\r\n" +
+	"\tMicrosoft\x10\x02\x12\b\n" +
+	"\x04OIDC\x10\x03\x12\b\n" +
+	"\x04SAML\x10\x042\xf4\t\n" +
 	"\bMyTenant\x12\x94\x01\n" +
 	"\x13GetMyPasswordPolicy\x12\x1b.api.MyPasswordPolicyGetReq\x1a\x1c.api.MyPasswordPolicyGetResp\"B\x8a\xb5\x18\x16\n" +
 	"\x0fpassword-policy\x1a\x03get\x82\xd3\xe4\x93\x02\"\x12 /api/mytenant/v1/password-policy\x12\xa3\x01\n" +
 	"\x16UpdateMyPasswordPolicy\x12\x1e.api.MyPasswordPolicyUpdateReq\x1a\x1f.api.MyPasswordPolicyUpdateResp\"H\x8a\xb5\x18\x19\n" +
-	"\x0fpassword-policy\x1a\x06update\x82\xd3\xe4\x93\x02%:\x01*\x1a /api/mytenant/v1/password-policyB+Z)github.com/go-core-stack/auth-gateway/apib\x06proto3"
+	"\x0fpassword-policy\x1a\x06update\x82\xd3\xe4\x93\x02%:\x01*\x1a /api/mytenant/v1/password-policy\x12\x8f\x01\n" +
+	"\x18GetIdentityProviderTypes\x12\x14.api.IdpProvidersReq\x1a\x15.api.IdpProvidersResp\"F\x8a\xb5\x18\x12\n" +
+	"\n" +
+	"tenant-idp\x1a\x04list\x82\xd3\xe4\x93\x02*\x12(/api/mytenant/v1/identity-provider-types\x12\x9e\x01\n" +
+	"\x1eCreateIdentityProviderInstance\x12\x19.api.IdpInstanceCreateReq\x1a\x1a.api.IdpInstanceCreateResp\"E\x8a\xb5\x18\x14\n" +
+	"\n" +
+	"tenant-idp\x1a\x06create\x82\xd3\xe4\x93\x02':\x01*\"\"/api/mytenant/v1/identity-provider\x12\x94\x01\n" +
+	"\x1dListIdentityProviderInstances\x12\x17.api.IdpInstanceListReq\x1a\x18.api.IdpInstanceListResp\"@\x8a\xb5\x18\x12\n" +
+	"\n" +
+	"tenant-idp\x1a\x04list\x82\xd3\xe4\x93\x02$\x12\"/api/mytenant/v1/identity-provider\x12\x95\x01\n" +
+	"\x1bGetIdentityProviderInstance\x12\x16.api.IdpInstanceGetReq\x1a\x17.api.IdpInstanceGetResp\"E\x8a\xb5\x18\x11\n" +
+	"\n" +
+	"tenant-idp\x1a\x03get\x82\xd3\xe4\x93\x02*\x12(/api/mytenant/v1/identity-provider/{key}\x12\xa4\x01\n" +
+	"\x1eUpdateIdentityProviderInstance\x12\x19.api.IdpInstanceUpdateReq\x1a\x1a.api.IdpInstanceUpdateResp\"K\x8a\xb5\x18\x14\n" +
+	"\n" +
+	"tenant-idp\x1a\x06update\x82\xd3\xe4\x93\x02-:\x01*\x1a(/api/mytenant/v1/identity-provider/{key}\x12\xa1\x01\n" +
+	"\x1eDeleteIdentityProviderInstance\x12\x19.api.IdpInstanceDeleteReq\x1a\x1a.api.IdpInstanceDeleteResp\"H\x8a\xb5\x18\x14\n" +
+	"\n" +
+	"tenant-idp\x1a\x06delete\x82\xd3\xe4\x93\x02**(/api/mytenant/v1/identity-provider/{key}B+Z)github.com/go-core-stack/auth-gateway/apib\x06proto3"
 
 var (
 	file_mytenant_proto_rawDescOnce sync.Once
@@ -385,23 +1594,61 @@ func file_mytenant_proto_rawDescGZIP() []byte {
 	return file_mytenant_proto_rawDescData
 }
 
-var file_mytenant_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_mytenant_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_mytenant_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_mytenant_proto_goTypes = []any{
-	(*MyPasswordPolicyGetReq)(nil),     // 0: api.MyPasswordPolicyGetReq
-	(*MyPasswordPolicyGetResp)(nil),    // 1: api.MyPasswordPolicyGetResp
-	(*MyPasswordPolicyUpdateReq)(nil),  // 2: api.MyPasswordPolicyUpdateReq
-	(*MyPasswordPolicyUpdateResp)(nil), // 3: api.MyPasswordPolicyUpdateResp
+	(IdpProviderType)(0),               // 0: api.IdpProviderType
+	(*MyPasswordPolicyGetReq)(nil),     // 1: api.MyPasswordPolicyGetReq
+	(*MyPasswordPolicyGetResp)(nil),    // 2: api.MyPasswordPolicyGetResp
+	(*MyPasswordPolicyUpdateReq)(nil),  // 3: api.MyPasswordPolicyUpdateReq
+	(*MyPasswordPolicyUpdateResp)(nil), // 4: api.MyPasswordPolicyUpdateResp
+	(*IdpConfigField)(nil),             // 5: api.IdpConfigField
+	(*IdpProviderMetadata)(nil),        // 6: api.IdpProviderMetadata
+	(*IdpProvidersReq)(nil),            // 7: api.IdpProvidersReq
+	(*IdpProvidersResp)(nil),           // 8: api.IdpProvidersResp
+	(*IdpInstanceCreateReq)(nil),       // 9: api.IdpInstanceCreateReq
+	(*IdpInstanceCreateResp)(nil),      // 10: api.IdpInstanceCreateResp
+	(*IdpInstanceListReq)(nil),         // 11: api.IdpInstanceListReq
+	(*IdpInstanceListResp)(nil),        // 12: api.IdpInstanceListResp
+	(*IdpInstanceSummary)(nil),         // 13: api.IdpInstanceSummary
+	(*IdpInstanceGetReq)(nil),          // 14: api.IdpInstanceGetReq
+	(*IdpInstanceGetResp)(nil),         // 15: api.IdpInstanceGetResp
+	(*IdpInstanceUpdateReq)(nil),       // 16: api.IdpInstanceUpdateReq
+	(*IdpInstanceUpdateResp)(nil),      // 17: api.IdpInstanceUpdateResp
+	(*IdpInstanceDeleteReq)(nil),       // 18: api.IdpInstanceDeleteReq
+	(*IdpInstanceDeleteResp)(nil),      // 19: api.IdpInstanceDeleteResp
 }
 var file_mytenant_proto_depIdxs = []int32{
-	0, // 0: api.MyTenant.GetMyPasswordPolicy:input_type -> api.MyPasswordPolicyGetReq
-	2, // 1: api.MyTenant.UpdateMyPasswordPolicy:input_type -> api.MyPasswordPolicyUpdateReq
-	1, // 2: api.MyTenant.GetMyPasswordPolicy:output_type -> api.MyPasswordPolicyGetResp
-	3, // 3: api.MyTenant.UpdateMyPasswordPolicy:output_type -> api.MyPasswordPolicyUpdateResp
-	2, // [2:4] is the sub-list for method output_type
-	0, // [0:2] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	0,  // 0: api.IdpProviderMetadata.provider_type:type_name -> api.IdpProviderType
+	5,  // 1: api.IdpProviderMetadata.config_fields:type_name -> api.IdpConfigField
+	0,  // 2: api.IdpProvidersReq.providerType:type_name -> api.IdpProviderType
+	6,  // 3: api.IdpProvidersResp.providers:type_name -> api.IdpProviderMetadata
+	0,  // 4: api.IdpInstanceCreateReq.provider_type:type_name -> api.IdpProviderType
+	0,  // 5: api.IdpInstanceListReq.provider_type:type_name -> api.IdpProviderType
+	13, // 6: api.IdpInstanceListResp.instances:type_name -> api.IdpInstanceSummary
+	0,  // 7: api.IdpInstanceSummary.provider_type:type_name -> api.IdpProviderType
+	0,  // 8: api.IdpInstanceGetResp.provider_type:type_name -> api.IdpProviderType
+	1,  // 9: api.MyTenant.GetMyPasswordPolicy:input_type -> api.MyPasswordPolicyGetReq
+	3,  // 10: api.MyTenant.UpdateMyPasswordPolicy:input_type -> api.MyPasswordPolicyUpdateReq
+	7,  // 11: api.MyTenant.GetIdentityProviderTypes:input_type -> api.IdpProvidersReq
+	9,  // 12: api.MyTenant.CreateIdentityProviderInstance:input_type -> api.IdpInstanceCreateReq
+	11, // 13: api.MyTenant.ListIdentityProviderInstances:input_type -> api.IdpInstanceListReq
+	14, // 14: api.MyTenant.GetIdentityProviderInstance:input_type -> api.IdpInstanceGetReq
+	16, // 15: api.MyTenant.UpdateIdentityProviderInstance:input_type -> api.IdpInstanceUpdateReq
+	18, // 16: api.MyTenant.DeleteIdentityProviderInstance:input_type -> api.IdpInstanceDeleteReq
+	2,  // 17: api.MyTenant.GetMyPasswordPolicy:output_type -> api.MyPasswordPolicyGetResp
+	4,  // 18: api.MyTenant.UpdateMyPasswordPolicy:output_type -> api.MyPasswordPolicyUpdateResp
+	8,  // 19: api.MyTenant.GetIdentityProviderTypes:output_type -> api.IdpProvidersResp
+	10, // 20: api.MyTenant.CreateIdentityProviderInstance:output_type -> api.IdpInstanceCreateResp
+	12, // 21: api.MyTenant.ListIdentityProviderInstances:output_type -> api.IdpInstanceListResp
+	15, // 22: api.MyTenant.GetIdentityProviderInstance:output_type -> api.IdpInstanceGetResp
+	17, // 23: api.MyTenant.UpdateIdentityProviderInstance:output_type -> api.IdpInstanceUpdateResp
+	19, // 24: api.MyTenant.DeleteIdentityProviderInstance:output_type -> api.IdpInstanceDeleteResp
+	17, // [17:25] is the sub-list for method output_type
+	9,  // [9:17] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_mytenant_proto_init() }
@@ -409,18 +1656,21 @@ func file_mytenant_proto_init() {
 	if File_mytenant_proto != nil {
 		return
 	}
+	file_mytenant_proto_msgTypes[6].OneofWrappers = []any{}
+	file_mytenant_proto_msgTypes[10].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_mytenant_proto_rawDesc), len(file_mytenant_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   4,
+			NumEnums:      1,
+			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_mytenant_proto_goTypes,
 		DependencyIndexes: file_mytenant_proto_depIdxs,
+		EnumInfos:         file_mytenant_proto_enumTypes,
 		MessageInfos:      file_mytenant_proto_msgTypes,
 	}.Build()
 	File_mytenant_proto = out.File

--- a/api/mytenant.pb.gw.go
+++ b/api/mytenant.pb.gw.go
@@ -78,6 +78,212 @@ func local_request_MyTenant_UpdateMyPasswordPolicy_0(ctx context.Context, marsha
 	return msg, metadata, err
 }
 
+var filter_MyTenant_GetIdentityProviderTypes_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_MyTenant_GetIdentityProviderTypes_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq IdpProvidersReq
+		metadata runtime.ServerMetadata
+	)
+	io.Copy(io.Discard, req.Body)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_MyTenant_GetIdentityProviderTypes_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.GetIdentityProviderTypes(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MyTenant_GetIdentityProviderTypes_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq IdpProvidersReq
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_MyTenant_GetIdentityProviderTypes_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.GetIdentityProviderTypes(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_MyTenant_CreateIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq IdpInstanceCreateReq
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.CreateIdentityProviderInstance(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MyTenant_CreateIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq IdpInstanceCreateReq
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.CreateIdentityProviderInstance(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+var filter_MyTenant_ListIdentityProviderInstances_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_MyTenant_ListIdentityProviderInstances_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq IdpInstanceListReq
+		metadata runtime.ServerMetadata
+	)
+	io.Copy(io.Discard, req.Body)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_MyTenant_ListIdentityProviderInstances_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.ListIdentityProviderInstances(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MyTenant_ListIdentityProviderInstances_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq IdpInstanceListReq
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_MyTenant_ListIdentityProviderInstances_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ListIdentityProviderInstances(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_MyTenant_GetIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq IdpInstanceGetReq
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	io.Copy(io.Discard, req.Body)
+	val, ok := pathParams["key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "key")
+	}
+	protoReq.Key, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
+	}
+	msg, err := client.GetIdentityProviderInstance(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MyTenant_GetIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq IdpInstanceGetReq
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "key")
+	}
+	protoReq.Key, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
+	}
+	msg, err := server.GetIdentityProviderInstance(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_MyTenant_UpdateIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq IdpInstanceUpdateReq
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "key")
+	}
+	protoReq.Key, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
+	}
+	msg, err := client.UpdateIdentityProviderInstance(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MyTenant_UpdateIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq IdpInstanceUpdateReq
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "key")
+	}
+	protoReq.Key, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
+	}
+	msg, err := server.UpdateIdentityProviderInstance(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_MyTenant_DeleteIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq IdpInstanceDeleteReq
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	io.Copy(io.Discard, req.Body)
+	val, ok := pathParams["key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "key")
+	}
+	protoReq.Key, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
+	}
+	msg, err := client.DeleteIdentityProviderInstance(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MyTenant_DeleteIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq IdpInstanceDeleteReq
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "key")
+	}
+	protoReq.Key, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
+	}
+	msg, err := server.DeleteIdentityProviderInstance(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterMyTenantHandlerServer registers the http handlers for service MyTenant to "mux".
 // UnaryRPC     :call MyTenantServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -123,6 +329,126 @@ func RegisterMyTenantHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 			return
 		}
 		forward_MyTenant_UpdateMyPasswordPolicy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_MyTenant_GetIdentityProviderTypes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/GetIdentityProviderTypes", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider-types"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MyTenant_GetIdentityProviderTypes_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_GetIdentityProviderTypes_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_MyTenant_CreateIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/CreateIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MyTenant_CreateIdentityProviderInstance_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_CreateIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_MyTenant_ListIdentityProviderInstances_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/ListIdentityProviderInstances", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MyTenant_ListIdentityProviderInstances_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_ListIdentityProviderInstances_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_MyTenant_GetIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/GetIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MyTenant_GetIdentityProviderInstance_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_GetIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPut, pattern_MyTenant_UpdateIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/UpdateIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MyTenant_UpdateIdentityProviderInstance_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_UpdateIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodDelete, pattern_MyTenant_DeleteIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/DeleteIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MyTenant_DeleteIdentityProviderInstance_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_DeleteIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -198,15 +524,129 @@ func RegisterMyTenantHandlerClient(ctx context.Context, mux *runtime.ServeMux, c
 		}
 		forward_MyTenant_UpdateMyPasswordPolicy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_MyTenant_GetIdentityProviderTypes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/GetIdentityProviderTypes", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider-types"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MyTenant_GetIdentityProviderTypes_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_GetIdentityProviderTypes_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_MyTenant_CreateIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/CreateIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MyTenant_CreateIdentityProviderInstance_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_CreateIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_MyTenant_ListIdentityProviderInstances_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/ListIdentityProviderInstances", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MyTenant_ListIdentityProviderInstances_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_ListIdentityProviderInstances_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_MyTenant_GetIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/GetIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MyTenant_GetIdentityProviderInstance_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_GetIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPut, pattern_MyTenant_UpdateIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/UpdateIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MyTenant_UpdateIdentityProviderInstance_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_UpdateIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodDelete, pattern_MyTenant_DeleteIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/DeleteIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MyTenant_DeleteIdentityProviderInstance_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MyTenant_DeleteIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_MyTenant_GetMyPasswordPolicy_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "password-policy"}, ""))
-	pattern_MyTenant_UpdateMyPasswordPolicy_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "password-policy"}, ""))
+	pattern_MyTenant_GetMyPasswordPolicy_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "password-policy"}, ""))
+	pattern_MyTenant_UpdateMyPasswordPolicy_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "password-policy"}, ""))
+	pattern_MyTenant_GetIdentityProviderTypes_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "identity-provider-types"}, ""))
+	pattern_MyTenant_CreateIdentityProviderInstance_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "identity-provider"}, ""))
+	pattern_MyTenant_ListIdentityProviderInstances_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "identity-provider"}, ""))
+	pattern_MyTenant_GetIdentityProviderInstance_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"api", "mytenant", "v1", "identity-provider", "key"}, ""))
+	pattern_MyTenant_UpdateIdentityProviderInstance_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"api", "mytenant", "v1", "identity-provider", "key"}, ""))
+	pattern_MyTenant_DeleteIdentityProviderInstance_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"api", "mytenant", "v1", "identity-provider", "key"}, ""))
 )
 
 var (
-	forward_MyTenant_GetMyPasswordPolicy_0    = runtime.ForwardResponseMessage
-	forward_MyTenant_UpdateMyPasswordPolicy_0 = runtime.ForwardResponseMessage
+	forward_MyTenant_GetMyPasswordPolicy_0            = runtime.ForwardResponseMessage
+	forward_MyTenant_UpdateMyPasswordPolicy_0         = runtime.ForwardResponseMessage
+	forward_MyTenant_GetIdentityProviderTypes_0       = runtime.ForwardResponseMessage
+	forward_MyTenant_CreateIdentityProviderInstance_0 = runtime.ForwardResponseMessage
+	forward_MyTenant_ListIdentityProviderInstances_0  = runtime.ForwardResponseMessage
+	forward_MyTenant_GetIdentityProviderInstance_0    = runtime.ForwardResponseMessage
+	forward_MyTenant_UpdateIdentityProviderInstance_0 = runtime.ForwardResponseMessage
+	forward_MyTenant_DeleteIdentityProviderInstance_0 = runtime.ForwardResponseMessage
 )

--- a/api/mytenant.pb.gw.go
+++ b/api/mytenant.pb.gw.go
@@ -78,99 +78,85 @@ func local_request_MyTenant_UpdateMyPasswordPolicy_0(ctx context.Context, marsha
 	return msg, metadata, err
 }
 
-var filter_MyTenant_GetIdentityProviderTypes_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
-
-func request_MyTenant_GetIdentityProviderTypes_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func request_MyTenant_GetMyIdentityProviderTypes_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq IdpProvidersReq
+		protoReq IdentityProviderTypesGetReq
+		metadata runtime.ServerMetadata
+	)
+	io.Copy(io.Discard, req.Body)
+	msg, err := client.GetMyIdentityProviderTypes(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MyTenant_GetMyIdentityProviderTypes_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq IdentityProviderTypesGetReq
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.GetMyIdentityProviderTypes(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_MyTenant_CreateMyIdentityProvider_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq MyIdentityProviderCreateReq
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.CreateMyIdentityProvider(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MyTenant_CreateMyIdentityProvider_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq MyIdentityProviderCreateReq
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.CreateMyIdentityProvider(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+var filter_MyTenant_ListMyIdentityProviders_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_MyTenant_ListMyIdentityProviders_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq MyIdentityProvidersListReq
 		metadata runtime.ServerMetadata
 	)
 	io.Copy(io.Discard, req.Body)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_MyTenant_GetIdentityProviderTypes_0); err != nil {
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_MyTenant_ListMyIdentityProviders_0); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	msg, err := client.GetIdentityProviderTypes(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.ListMyIdentityProviders(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
 
-func local_request_MyTenant_GetIdentityProviderTypes_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func local_request_MyTenant_ListMyIdentityProviders_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq IdpProvidersReq
+		protoReq MyIdentityProvidersListReq
 		metadata runtime.ServerMetadata
 	)
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_MyTenant_GetIdentityProviderTypes_0); err != nil {
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_MyTenant_ListMyIdentityProviders_0); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	msg, err := server.GetIdentityProviderTypes(ctx, &protoReq)
+	msg, err := server.ListMyIdentityProviders(ctx, &protoReq)
 	return msg, metadata, err
 }
 
-func request_MyTenant_CreateIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func request_MyTenant_GetMyIdentityProvider_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq IdpInstanceCreateReq
-		metadata runtime.ServerMetadata
-	)
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-	msg, err := client.CreateIdentityProviderInstance(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
-	return msg, metadata, err
-}
-
-func local_request_MyTenant_CreateIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var (
-		protoReq IdpInstanceCreateReq
-		metadata runtime.ServerMetadata
-	)
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-	msg, err := server.CreateIdentityProviderInstance(ctx, &protoReq)
-	return msg, metadata, err
-}
-
-var filter_MyTenant_ListIdentityProviderInstances_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
-
-func request_MyTenant_ListIdentityProviderInstances_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var (
-		protoReq IdpInstanceListReq
-		metadata runtime.ServerMetadata
-	)
-	io.Copy(io.Discard, req.Body)
-	if err := req.ParseForm(); err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_MyTenant_ListIdentityProviderInstances_0); err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-	msg, err := client.ListIdentityProviderInstances(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
-	return msg, metadata, err
-}
-
-func local_request_MyTenant_ListIdentityProviderInstances_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var (
-		protoReq IdpInstanceListReq
-		metadata runtime.ServerMetadata
-	)
-	if err := req.ParseForm(); err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_MyTenant_ListIdentityProviderInstances_0); err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-	msg, err := server.ListIdentityProviderInstances(ctx, &protoReq)
-	return msg, metadata, err
-}
-
-func request_MyTenant_GetIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var (
-		protoReq IdpInstanceGetReq
+		protoReq MyIdentityProviderGetReq
 		metadata runtime.ServerMetadata
 		err      error
 	)
@@ -183,13 +169,13 @@ func request_MyTenant_GetIdentityProviderInstance_0(ctx context.Context, marshal
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
 	}
-	msg, err := client.GetIdentityProviderInstance(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.GetMyIdentityProvider(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
 
-func local_request_MyTenant_GetIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func local_request_MyTenant_GetMyIdentityProvider_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq IdpInstanceGetReq
+		protoReq MyIdentityProviderGetReq
 		metadata runtime.ServerMetadata
 		err      error
 	)
@@ -201,13 +187,13 @@ func local_request_MyTenant_GetIdentityProviderInstance_0(ctx context.Context, m
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
 	}
-	msg, err := server.GetIdentityProviderInstance(ctx, &protoReq)
+	msg, err := server.GetMyIdentityProvider(ctx, &protoReq)
 	return msg, metadata, err
 }
 
-func request_MyTenant_UpdateIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func request_MyTenant_UpdateMyIdentityProvider_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq IdpInstanceUpdateReq
+		protoReq MyIdentityProviderUpdateReq
 		metadata runtime.ServerMetadata
 		err      error
 	)
@@ -222,13 +208,13 @@ func request_MyTenant_UpdateIdentityProviderInstance_0(ctx context.Context, mars
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
 	}
-	msg, err := client.UpdateIdentityProviderInstance(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.UpdateMyIdentityProvider(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
 
-func local_request_MyTenant_UpdateIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func local_request_MyTenant_UpdateMyIdentityProvider_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq IdpInstanceUpdateReq
+		protoReq MyIdentityProviderUpdateReq
 		metadata runtime.ServerMetadata
 		err      error
 	)
@@ -243,13 +229,13 @@ func local_request_MyTenant_UpdateIdentityProviderInstance_0(ctx context.Context
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
 	}
-	msg, err := server.UpdateIdentityProviderInstance(ctx, &protoReq)
+	msg, err := server.UpdateMyIdentityProvider(ctx, &protoReq)
 	return msg, metadata, err
 }
 
-func request_MyTenant_DeleteIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func request_MyTenant_DeleteMyIdentityProvider_0(ctx context.Context, marshaler runtime.Marshaler, client MyTenantClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq IdpInstanceDeleteReq
+		protoReq MyIdentityProviderDeleteReq
 		metadata runtime.ServerMetadata
 		err      error
 	)
@@ -262,13 +248,13 @@ func request_MyTenant_DeleteIdentityProviderInstance_0(ctx context.Context, mars
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
 	}
-	msg, err := client.DeleteIdentityProviderInstance(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.DeleteMyIdentityProvider(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
 
-func local_request_MyTenant_DeleteIdentityProviderInstance_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func local_request_MyTenant_DeleteMyIdentityProvider_0(ctx context.Context, marshaler runtime.Marshaler, server MyTenantServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq IdpInstanceDeleteReq
+		protoReq MyIdentityProviderDeleteReq
 		metadata runtime.ServerMetadata
 		err      error
 	)
@@ -280,7 +266,7 @@ func local_request_MyTenant_DeleteIdentityProviderInstance_0(ctx context.Context
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
 	}
-	msg, err := server.DeleteIdentityProviderInstance(ctx, &protoReq)
+	msg, err := server.DeleteMyIdentityProvider(ctx, &protoReq)
 	return msg, metadata, err
 }
 
@@ -330,125 +316,125 @@ func RegisterMyTenantHandlerServer(ctx context.Context, mux *runtime.ServeMux, s
 		}
 		forward_MyTenant_UpdateMyPasswordPolicy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodGet, pattern_MyTenant_GetIdentityProviderTypes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodGet, pattern_MyTenant_GetMyIdentityProviderTypes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/GetIdentityProviderTypes", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider-types"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/GetMyIdentityProviderTypes", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider-types"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_MyTenant_GetIdentityProviderTypes_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_MyTenant_GetMyIdentityProviderTypes_0(annotatedContext, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_MyTenant_GetIdentityProviderTypes_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_MyTenant_GetMyIdentityProviderTypes_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPost, pattern_MyTenant_CreateIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPost, pattern_MyTenant_CreateMyIdentityProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/CreateIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/CreateMyIdentityProvider", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_MyTenant_CreateIdentityProviderInstance_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_MyTenant_CreateMyIdentityProvider_0(annotatedContext, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_MyTenant_CreateIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_MyTenant_CreateMyIdentityProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodGet, pattern_MyTenant_ListIdentityProviderInstances_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodGet, pattern_MyTenant_ListMyIdentityProviders_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/ListIdentityProviderInstances", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/ListMyIdentityProviders", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-providers"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_MyTenant_ListIdentityProviderInstances_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_MyTenant_ListMyIdentityProviders_0(annotatedContext, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_MyTenant_ListIdentityProviderInstances_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_MyTenant_ListMyIdentityProviders_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodGet, pattern_MyTenant_GetIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodGet, pattern_MyTenant_GetMyIdentityProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/GetIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/GetMyIdentityProvider", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_MyTenant_GetIdentityProviderInstance_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_MyTenant_GetMyIdentityProvider_0(annotatedContext, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_MyTenant_GetIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_MyTenant_GetMyIdentityProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPut, pattern_MyTenant_UpdateIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPut, pattern_MyTenant_UpdateMyIdentityProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/UpdateIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/UpdateMyIdentityProvider", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_MyTenant_UpdateIdentityProviderInstance_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_MyTenant_UpdateMyIdentityProvider_0(annotatedContext, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_MyTenant_UpdateIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_MyTenant_UpdateMyIdentityProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodDelete, pattern_MyTenant_DeleteIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodDelete, pattern_MyTenant_DeleteMyIdentityProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/DeleteIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.MyTenant/DeleteMyIdentityProvider", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_MyTenant_DeleteIdentityProviderInstance_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_MyTenant_DeleteMyIdentityProvider_0(annotatedContext, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_MyTenant_DeleteIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_MyTenant_DeleteMyIdentityProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -524,129 +510,129 @@ func RegisterMyTenantHandlerClient(ctx context.Context, mux *runtime.ServeMux, c
 		}
 		forward_MyTenant_UpdateMyPasswordPolicy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodGet, pattern_MyTenant_GetIdentityProviderTypes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodGet, pattern_MyTenant_GetMyIdentityProviderTypes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/GetIdentityProviderTypes", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider-types"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/GetMyIdentityProviderTypes", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider-types"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_MyTenant_GetIdentityProviderTypes_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_MyTenant_GetMyIdentityProviderTypes_0(annotatedContext, inboundMarshaler, client, req, pathParams)
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_MyTenant_GetIdentityProviderTypes_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_MyTenant_GetMyIdentityProviderTypes_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPost, pattern_MyTenant_CreateIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPost, pattern_MyTenant_CreateMyIdentityProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/CreateIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/CreateMyIdentityProvider", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_MyTenant_CreateIdentityProviderInstance_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_MyTenant_CreateMyIdentityProvider_0(annotatedContext, inboundMarshaler, client, req, pathParams)
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_MyTenant_CreateIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_MyTenant_CreateMyIdentityProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodGet, pattern_MyTenant_ListIdentityProviderInstances_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodGet, pattern_MyTenant_ListMyIdentityProviders_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/ListIdentityProviderInstances", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/ListMyIdentityProviders", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-providers"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_MyTenant_ListIdentityProviderInstances_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_MyTenant_ListMyIdentityProviders_0(annotatedContext, inboundMarshaler, client, req, pathParams)
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_MyTenant_ListIdentityProviderInstances_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_MyTenant_ListMyIdentityProviders_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodGet, pattern_MyTenant_GetIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodGet, pattern_MyTenant_GetMyIdentityProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/GetIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/GetMyIdentityProvider", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_MyTenant_GetIdentityProviderInstance_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_MyTenant_GetMyIdentityProvider_0(annotatedContext, inboundMarshaler, client, req, pathParams)
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_MyTenant_GetIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_MyTenant_GetMyIdentityProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPut, pattern_MyTenant_UpdateIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPut, pattern_MyTenant_UpdateMyIdentityProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/UpdateIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/UpdateMyIdentityProvider", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_MyTenant_UpdateIdentityProviderInstance_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_MyTenant_UpdateMyIdentityProvider_0(annotatedContext, inboundMarshaler, client, req, pathParams)
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_MyTenant_UpdateIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_MyTenant_UpdateMyIdentityProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodDelete, pattern_MyTenant_DeleteIdentityProviderInstance_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodDelete, pattern_MyTenant_DeleteMyIdentityProvider_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/DeleteIdentityProviderInstance", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.MyTenant/DeleteMyIdentityProvider", runtime.WithHTTPPathPattern("/api/mytenant/v1/identity-provider/{key}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_MyTenant_DeleteIdentityProviderInstance_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_MyTenant_DeleteMyIdentityProvider_0(annotatedContext, inboundMarshaler, client, req, pathParams)
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_MyTenant_DeleteIdentityProviderInstance_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_MyTenant_DeleteMyIdentityProvider_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	return nil
 }
 
 var (
-	pattern_MyTenant_GetMyPasswordPolicy_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "password-policy"}, ""))
-	pattern_MyTenant_UpdateMyPasswordPolicy_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "password-policy"}, ""))
-	pattern_MyTenant_GetIdentityProviderTypes_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "identity-provider-types"}, ""))
-	pattern_MyTenant_CreateIdentityProviderInstance_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "identity-provider"}, ""))
-	pattern_MyTenant_ListIdentityProviderInstances_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "identity-provider"}, ""))
-	pattern_MyTenant_GetIdentityProviderInstance_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"api", "mytenant", "v1", "identity-provider", "key"}, ""))
-	pattern_MyTenant_UpdateIdentityProviderInstance_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"api", "mytenant", "v1", "identity-provider", "key"}, ""))
-	pattern_MyTenant_DeleteIdentityProviderInstance_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"api", "mytenant", "v1", "identity-provider", "key"}, ""))
+	pattern_MyTenant_GetMyPasswordPolicy_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "password-policy"}, ""))
+	pattern_MyTenant_UpdateMyPasswordPolicy_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "password-policy"}, ""))
+	pattern_MyTenant_GetMyIdentityProviderTypes_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "identity-provider-types"}, ""))
+	pattern_MyTenant_CreateMyIdentityProvider_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "identity-provider"}, ""))
+	pattern_MyTenant_ListMyIdentityProviders_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "mytenant", "v1", "identity-providers"}, ""))
+	pattern_MyTenant_GetMyIdentityProvider_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"api", "mytenant", "v1", "identity-provider", "key"}, ""))
+	pattern_MyTenant_UpdateMyIdentityProvider_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"api", "mytenant", "v1", "identity-provider", "key"}, ""))
+	pattern_MyTenant_DeleteMyIdentityProvider_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"api", "mytenant", "v1", "identity-provider", "key"}, ""))
 )
 
 var (
-	forward_MyTenant_GetMyPasswordPolicy_0            = runtime.ForwardResponseMessage
-	forward_MyTenant_UpdateMyPasswordPolicy_0         = runtime.ForwardResponseMessage
-	forward_MyTenant_GetIdentityProviderTypes_0       = runtime.ForwardResponseMessage
-	forward_MyTenant_CreateIdentityProviderInstance_0 = runtime.ForwardResponseMessage
-	forward_MyTenant_ListIdentityProviderInstances_0  = runtime.ForwardResponseMessage
-	forward_MyTenant_GetIdentityProviderInstance_0    = runtime.ForwardResponseMessage
-	forward_MyTenant_UpdateIdentityProviderInstance_0 = runtime.ForwardResponseMessage
-	forward_MyTenant_DeleteIdentityProviderInstance_0 = runtime.ForwardResponseMessage
+	forward_MyTenant_GetMyPasswordPolicy_0        = runtime.ForwardResponseMessage
+	forward_MyTenant_UpdateMyPasswordPolicy_0     = runtime.ForwardResponseMessage
+	forward_MyTenant_GetMyIdentityProviderTypes_0 = runtime.ForwardResponseMessage
+	forward_MyTenant_CreateMyIdentityProvider_0   = runtime.ForwardResponseMessage
+	forward_MyTenant_ListMyIdentityProviders_0    = runtime.ForwardResponseMessage
+	forward_MyTenant_GetMyIdentityProvider_0      = runtime.ForwardResponseMessage
+	forward_MyTenant_UpdateMyIdentityProvider_0   = runtime.ForwardResponseMessage
+	forward_MyTenant_DeleteMyIdentityProvider_0   = runtime.ForwardResponseMessage
 )

--- a/api/mytenant.pb.route.go
+++ b/api/mytenant.pb.route.go
@@ -22,37 +22,37 @@ func init() {
 	route.Verb = "update"
 	RoutesMyTenant = append(RoutesMyTenant, route)
 
-	// Adding Route information for GetIdentityProviderTypes RPC
+	// Adding Route information for GetMyIdentityProviderTypes RPC
 	route = model.NewRoute("/api/mytenant/v1/identity-provider-types", "GET")
 	route.Resource = "tenant-idp"
-	route.Verb = "list"
+	route.Verb = "list-types"
 	RoutesMyTenant = append(RoutesMyTenant, route)
 
-	// Adding Route information for CreateIdentityProviderInstance RPC
+	// Adding Route information for CreateMyIdentityProvider RPC
 	route = model.NewRoute("/api/mytenant/v1/identity-provider", "POST")
 	route.Resource = "tenant-idp"
 	route.Verb = "create"
 	RoutesMyTenant = append(RoutesMyTenant, route)
 
-	// Adding Route information for ListIdentityProviderInstances RPC
-	route = model.NewRoute("/api/mytenant/v1/identity-provider", "GET")
+	// Adding Route information for ListMyIdentityProviders RPC
+	route = model.NewRoute("/api/mytenant/v1/identity-providers", "GET")
 	route.Resource = "tenant-idp"
 	route.Verb = "list"
 	RoutesMyTenant = append(RoutesMyTenant, route)
 
-	// Adding Route information for GetIdentityProviderInstance RPC
+	// Adding Route information for GetMyIdentityProvider RPC
 	route = model.NewRoute("/api/mytenant/v1/identity-provider/{key}", "GET")
 	route.Resource = "tenant-idp"
 	route.Verb = "get"
 	RoutesMyTenant = append(RoutesMyTenant, route)
 
-	// Adding Route information for UpdateIdentityProviderInstance RPC
+	// Adding Route information for UpdateMyIdentityProvider RPC
 	route = model.NewRoute("/api/mytenant/v1/identity-provider/{key}", "PUT")
 	route.Resource = "tenant-idp"
 	route.Verb = "update"
 	RoutesMyTenant = append(RoutesMyTenant, route)
 
-	// Adding Route information for DeleteIdentityProviderInstance RPC
+	// Adding Route information for DeleteMyIdentityProvider RPC
 	route = model.NewRoute("/api/mytenant/v1/identity-provider/{key}", "DELETE")
 	route.Resource = "tenant-idp"
 	route.Verb = "delete"

--- a/api/mytenant.pb.route.go
+++ b/api/mytenant.pb.route.go
@@ -21,4 +21,40 @@ func init() {
 	route.Resource = "password-policy"
 	route.Verb = "update"
 	RoutesMyTenant = append(RoutesMyTenant, route)
+
+	// Adding Route information for GetIdentityProviderTypes RPC
+	route = model.NewRoute("/api/mytenant/v1/identity-provider-types", "GET")
+	route.Resource = "tenant-idp"
+	route.Verb = "list"
+	RoutesMyTenant = append(RoutesMyTenant, route)
+
+	// Adding Route information for CreateIdentityProviderInstance RPC
+	route = model.NewRoute("/api/mytenant/v1/identity-provider", "POST")
+	route.Resource = "tenant-idp"
+	route.Verb = "create"
+	RoutesMyTenant = append(RoutesMyTenant, route)
+
+	// Adding Route information for ListIdentityProviderInstances RPC
+	route = model.NewRoute("/api/mytenant/v1/identity-provider", "GET")
+	route.Resource = "tenant-idp"
+	route.Verb = "list"
+	RoutesMyTenant = append(RoutesMyTenant, route)
+
+	// Adding Route information for GetIdentityProviderInstance RPC
+	route = model.NewRoute("/api/mytenant/v1/identity-provider/{key}", "GET")
+	route.Resource = "tenant-idp"
+	route.Verb = "get"
+	RoutesMyTenant = append(RoutesMyTenant, route)
+
+	// Adding Route information for UpdateIdentityProviderInstance RPC
+	route = model.NewRoute("/api/mytenant/v1/identity-provider/{key}", "PUT")
+	route.Resource = "tenant-idp"
+	route.Verb = "update"
+	RoutesMyTenant = append(RoutesMyTenant, route)
+
+	// Adding Route information for DeleteIdentityProviderInstance RPC
+	route = model.NewRoute("/api/mytenant/v1/identity-provider/{key}", "DELETE")
+	route.Resource = "tenant-idp"
+	route.Verb = "delete"
+	RoutesMyTenant = append(RoutesMyTenant, route)
 }

--- a/api/mytenant.proto
+++ b/api/mytenant.proto
@@ -36,18 +36,18 @@ service MyTenant {
   }
 
   // List supported identity provider types (like Keycloak providers endpoint)
-  rpc GetIdentityProviderTypes(IdpProvidersReq) returns (IdpProvidersResp) {
+  rpc GetMyIdentityProviderTypes(IdentityProviderTypesGetReq) returns (IdentityProviderTypesGetResp) {
     option (google.api.http) = {
       get: "/api/mytenant/v1/identity-provider-types"
     };
     option (api.role) = {
       resource: "tenant-idp"
-      verb: "list"
+      verb: "list-types"
     };
   }
 
   // Create identity provider instance (like Keycloak instances endpoint)
-  rpc CreateIdentityProviderInstance(IdpInstanceCreateReq) returns (IdpInstanceCreateResp) {
+  rpc CreateMyIdentityProvider(MyIdentityProviderCreateReq) returns (MyIdentityProviderCreateResp) {
     option (google.api.http) = {
       post: "/api/mytenant/v1/identity-provider"
       body: "*"
@@ -59,9 +59,9 @@ service MyTenant {
   }
 
   // List all configured identity provider instances for the tenant
-  rpc ListIdentityProviderInstances(IdpInstanceListReq) returns (IdpInstanceListResp) {
+  rpc ListMyIdentityProviders(MyIdentityProvidersListReq) returns (MyIdentityProvidersListResp) {
     option (google.api.http) = {
-      get: "/api/mytenant/v1/identity-provider"
+      get: "/api/mytenant/v1/identity-providers"
     };
     option (api.role) = {
       resource: "tenant-idp"
@@ -69,8 +69,8 @@ service MyTenant {
     };
   }
 
-  // Get identity provider instance configuration (like Keycloak instances endpoint)
-  rpc GetIdentityProviderInstance(IdpInstanceGetReq) returns (IdpInstanceGetResp) {
+  // Get identity provider configuration (like Keycloak instances endpoint)
+  rpc GetMyIdentityProvider(MyIdentityProviderGetReq) returns (MyIdentityProviderGetResp) {
     option (google.api.http) = {
       get: "/api/mytenant/v1/identity-provider/{key}"
     };
@@ -80,8 +80,8 @@ service MyTenant {
     };
   }
 
-  // Update identity provider instance configuration (like Keycloak instances endpoint)
-  rpc UpdateIdentityProviderInstance(IdpInstanceUpdateReq) returns (IdpInstanceUpdateResp) {
+  // Update identity provider configuration (like Keycloak instances endpoint)
+  rpc UpdateMyIdentityProvider(MyIdentityProviderUpdateReq) returns (MyIdentityProviderUpdateResp) {
     option (google.api.http) = {
       put: "/api/mytenant/v1/identity-provider/{key}"
       body: "*"
@@ -92,8 +92,8 @@ service MyTenant {
     };
   }
 
-  // Delete identity provider instance (like Keycloak instances endpoint)
-  rpc DeleteIdentityProviderInstance(IdpInstanceDeleteReq) returns (IdpInstanceDeleteResp) {
+  // Delete identity provider (like Keycloak instances endpoint)
+  rpc DeleteMyIdentityProvider(MyIdentityProviderDeleteReq) returns (MyIdentityProviderDeleteResp) {
     option (google.api.http) = {
       delete: "/api/mytenant/v1/identity-provider/{key}"
     };
@@ -172,13 +172,18 @@ message MyPasswordPolicyUpdateReq {
 message MyPasswordPolicyUpdateResp {
 }
 
-// Identity Provider types
-enum IdpProviderType {
-  IdentityProviderUnspecified = 0;
-  Google = 1;
-  Microsoft = 2;
-  OIDC = 3;
-  SAML = 4;
+message IdentityProviderDefs {
+  // Identity Provider types
+  enum Type {
+    // Unspecified IDP
+    IdentityProviderUnspecified = 0;
+
+    // Identity Provider - Google
+    Google = 1;
+
+    // Identity Provider - Microsoft
+    Microsoft = 2;
+  }
 }
 
 // Configuration field metadata for validation
@@ -192,63 +197,76 @@ message IdpConfigField {
   string validation = 7;
 }
 
-// Provider metadata
-message IdpProviderMetadata {
-  IdpProviderType provider_type = 1;
-  string display_name = 2;
-  string description = 3;
-  repeated IdpConfigField config_fields = 4;
-  repeated string supported_scopes = 5;
-  repeated string default_scopes = 6;
-  string documentation = 7;
+// Identity provider providers request (list supported provider types)
+message IdentityProviderTypesGetReq {
 }
 
-// Identity provider providers request (list supported provider types)
-message IdpProvidersReq {
-  // Optional filter by provider type
-  optional IdpProviderType providerType = 1;
+message IdentityProviderTypesListEntry {
+  // type value for the list entry
+  string type = 1;
 }
 
 // Identity provider providers response
-message IdpProvidersResp {
-  // Available provider types and their metadata
-  repeated IdpProviderMetadata providers = 1;
+message IdentityProviderTypesGetResp {
+  // Available provider types
+  repeated IdentityProviderTypesListEntry providers = 1;
 }
 
-// Identity provider instance create request
-message IdpInstanceCreateReq {
-  // Identity provider key (unique per tenant)
+message GoogleIDPConfig {
+  // client id from google SSO config, where controller
+  // is enabled as client
+  string clientId = 1;
+
+  // client secret to validate ourself with google
+  string clientSecret = 2;
+
+  // Hosted Domain for allowing users only from specific domain
+  string hostedDomain = 3;
+}
+
+message MicrosoftIDPConfig {
+  // client id from microsoft SSO config, where controller
+  // is enabled as client
+  string clientId = 1;
+
+  // client secret to validate ourself with microsoft
+  string clientSecret = 2;
+
+  // tenant id to ensure allowing users only from specific
+  // microsoft tenant
+  string tenantId = 3;
+}
+
+// Identity provider create request
+message MyIdentityProviderCreateReq {
+  // Identity provider key (unique per tenant), also used for
+  // hosting SSO broker endpoint
   string key = 1;
 
   // Display name
-  string display_name = 2;
+  string dispName = 2;
 
   // Provider type
-  IdpProviderType provider_type = 3;
+  IdentityProviderDefs.Type type = 3;
 
   // Whether configuration is enabled
   bool enabled = 4;
 
-  // Display order for UI
-  int32 display_order = 5;
+  // configuration for Google Identity Provider
+  GoogleIDPConfig google = 5;
 
-  // Provider configuration (including sensitive fields)
-  string configuration = 6;
+  // configuration for Microsoft Identity Provider
+  MicrosoftIDPConfig microsoft = 6;
 }
 
-// Identity provider instance create response
-message IdpInstanceCreateResp {
-  // Created identity provider key
-  string key = 1;
-
-  // Success message
-  string message = 2;
+// Identity provider create response
+message MyIdentityProviderCreateResp {
 }
 
-// Identity provider instance list request
-message IdpInstanceListReq {
+// Identity provider list request
+message MyIdentityProvidersListReq {
   // Optional filter by provider type
-  optional IdpProviderType provider_type = 1;
+  optional IdentityProviderDefs.Type type = 1;
 
   // Optional filter by enabled status
   optional bool enabled = 2;
@@ -260,110 +278,97 @@ message IdpInstanceListReq {
   optional int32 offset = 4;
 }
 
+// Identity provider list entry
+message MyIdentityProvidersListEntry {
+  // Identity provider key
+  string key = 1;
+
+  // Display name
+  string dispName = 2;
+
+  // Provider type
+  IdentityProviderDefs.Type type = 3;
+
+  // Whether configuration is enabled
+  bool enabled = 4;
+
+  // Created timestamp
+  int64 created = 5;
+}
+
 // Identity provider instance list response
-message IdpInstanceListResp {
-  // List of identity provider instances
-  repeated IdpInstanceSummary instances = 1;
+message MyIdentityProvidersListResp {
+  // Count of IDP available
+  int32 count = 1;
 
-  // Total count of instances (for pagination)
-  int32 total_count = 2;
+  // List of identity providers
+  repeated MyIdentityProvidersListEntry items = 2;
 }
 
-// Identity provider instance summary (for list responses)
-message IdpInstanceSummary {
+// Identity provider get request
+message MyIdentityProviderGetReq {
+  // Identity provider key
+  string key = 1;
+}
+
+// Identity provider get response
+message MyIdentityProviderGetResp {
   // Identity provider key
   string key = 1;
 
   // Display name
-  string display_name = 2;
+  string dispName = 2;
 
   // Provider type
-  IdpProviderType provider_type = 3;
+  IdentityProviderDefs.Type type = 3;
 
   // Whether configuration is enabled
   bool enabled = 4;
 
-  // Display order for UI
-  int32 display_order = 5;
-
   // Created timestamp
-  int64 created = 6;
-
-  // Updated timestamp
-  int64 updated = 7;
-}
-
-// Identity provider instance get request
-message IdpInstanceGetReq {
-  // Identity provider key
-  string key = 1;
-}
-
-// Identity provider instance get response
-message IdpInstanceGetResp {
-  // Identity provider key
-  string key = 1;
-
-  // Display name
-  string display_name = 2;
-
-  // Provider type
-  IdpProviderType provider_type = 3;
-
-  // Whether configuration is enabled
-  bool enabled = 4;
-
-  // Display order for UI
-  int32 display_order = 5;
-
-  // Provider configuration (non-sensitive fields only)
-  string configuration = 6;
-
-  // Created timestamp
-  int64 created = 7;
-
-  // Updated timestamp
-  int64 updated = 8;
+  int64 created = 5;
 
   // Created by user
-  string created_by = 9;
+  string created_by = 6;
 
-  // Updated by user
-  string updated_by = 10;
+  // configuration for Google Identity Provider
+  GoogleIDPConfig google = 7;
+
+  // configuration for Microsoft Identity Provider
+  MicrosoftIDPConfig microsoft = 8;
 }
 
-// Identity provider instance update request
-message IdpInstanceUpdateReq {
+// Identity provider update request
+message MyIdentityProviderUpdateReq {
   // Identity provider key
   string key = 1;
 
   // Display name
-  string display_name = 2;
+  string dispName = 2;
 
   // Whether configuration is enabled
   bool enabled = 3;
 
-  // Display order for UI
-  int32 display_order = 4;
+  // Provider type
+  IdentityProviderDefs.Type type = 4;
 
-  // Provider configuration (including sensitive fields)
-  string configuration = 5;
+  // configuration for Google Identity Provider
+  GoogleIDPConfig google = 5;
+
+  // configuration for Microsoft Identity Provider
+  MicrosoftIDPConfig microsoft = 6;
 }
 
-// Identity provider instance update response
-message IdpInstanceUpdateResp {
-  // Success message
-  string message = 1;
+// Identity provider update response
+message MyIdentityProviderUpdateResp {
 }
 
-// Identity provider instance delete request
-message IdpInstanceDeleteReq {
+// Identity provider delete request
+message MyIdentityProviderDeleteReq {
   // Identity provider key
   string key = 1;
 }
 
-// Identity provider instance delete response
-message IdpInstanceDeleteResp {
-  // Success message
-  string message = 1;
+// Identity provider delete response
+message MyIdentityProviderDeleteResp {
 }

--- a/api/mytenant.proto
+++ b/api/mytenant.proto
@@ -34,6 +34,74 @@ service MyTenant {
       verb: "update"
     };
   }
+
+  // List supported identity provider types (like Keycloak providers endpoint)
+  rpc GetIdentityProviderTypes(IdpProvidersReq) returns (IdpProvidersResp) {
+    option (google.api.http) = {
+      get: "/api/mytenant/v1/identity-provider-types"
+    };
+    option (api.role) = {
+      resource: "tenant-idp"
+      verb: "list"
+    };
+  }
+
+  // Create identity provider instance (like Keycloak instances endpoint)
+  rpc CreateIdentityProviderInstance(IdpInstanceCreateReq) returns (IdpInstanceCreateResp) {
+    option (google.api.http) = {
+      post: "/api/mytenant/v1/identity-provider"
+      body: "*"
+    };
+    option (api.role) = {
+      resource: "tenant-idp"
+      verb: "create"
+    };
+  }
+
+  // List all configured identity provider instances for the tenant
+  rpc ListIdentityProviderInstances(IdpInstanceListReq) returns (IdpInstanceListResp) {
+    option (google.api.http) = {
+      get: "/api/mytenant/v1/identity-provider"
+    };
+    option (api.role) = {
+      resource: "tenant-idp"
+      verb: "list"
+    };
+  }
+
+  // Get identity provider instance configuration (like Keycloak instances endpoint)
+  rpc GetIdentityProviderInstance(IdpInstanceGetReq) returns (IdpInstanceGetResp) {
+    option (google.api.http) = {
+      get: "/api/mytenant/v1/identity-provider/{key}"
+    };
+    option (api.role) = {
+      resource: "tenant-idp"
+      verb: "get"
+    };
+  }
+
+  // Update identity provider instance configuration (like Keycloak instances endpoint)
+  rpc UpdateIdentityProviderInstance(IdpInstanceUpdateReq) returns (IdpInstanceUpdateResp) {
+    option (google.api.http) = {
+      put: "/api/mytenant/v1/identity-provider/{key}"
+      body: "*"
+    };
+    option (api.role) = {
+      resource: "tenant-idp"
+      verb: "update"
+    };
+  }
+
+  // Delete identity provider instance (like Keycloak instances endpoint)
+  rpc DeleteIdentityProviderInstance(IdpInstanceDeleteReq) returns (IdpInstanceDeleteResp) {
+    option (google.api.http) = {
+      delete: "/api/mytenant/v1/identity-provider/{key}"
+    };
+    option (api.role) = {
+      resource: "tenant-idp"
+      verb: "delete"
+    };
+  }
 }
 
 // password policy get request
@@ -102,4 +170,200 @@ message MyPasswordPolicyUpdateReq {
 
 // password policy update response
 message MyPasswordPolicyUpdateResp {
+}
+
+// Identity Provider types
+enum IdpProviderType {
+  IdentityProviderUnspecified = 0;
+  Google = 1;
+  Microsoft = 2;
+  OIDC = 3;
+  SAML = 4;
+}
+
+// Configuration field metadata for validation
+message IdpConfigField {
+  string name = 1;
+  string type = 2;
+  bool required = 3;
+  bool sensitive = 4;
+  string description = 5;
+  string default_value = 6;
+  string validation = 7;
+}
+
+// Provider metadata
+message IdpProviderMetadata {
+  IdpProviderType provider_type = 1;
+  string display_name = 2;
+  string description = 3;
+  repeated IdpConfigField config_fields = 4;
+  repeated string supported_scopes = 5;
+  repeated string default_scopes = 6;
+  string documentation = 7;
+}
+
+// Identity provider providers request (list supported provider types)
+message IdpProvidersReq {
+  // Optional filter by provider type
+  optional IdpProviderType providerType = 1;
+}
+
+// Identity provider providers response
+message IdpProvidersResp {
+  // Available provider types and their metadata
+  repeated IdpProviderMetadata providers = 1;
+}
+
+// Identity provider instance create request
+message IdpInstanceCreateReq {
+  // Identity provider key (unique per tenant)
+  string key = 1;
+
+  // Display name
+  string display_name = 2;
+
+  // Provider type
+  IdpProviderType provider_type = 3;
+
+  // Whether configuration is enabled
+  bool enabled = 4;
+
+  // Display order for UI
+  int32 display_order = 5;
+
+  // Provider configuration (including sensitive fields)
+  string configuration = 6;
+}
+
+// Identity provider instance create response
+message IdpInstanceCreateResp {
+  // Created identity provider key
+  string key = 1;
+
+  // Success message
+  string message = 2;
+}
+
+// Identity provider instance list request
+message IdpInstanceListReq {
+  // Optional filter by provider type
+  optional IdpProviderType provider_type = 1;
+
+  // Optional filter by enabled status
+  optional bool enabled = 2;
+
+  // Optional pagination limit
+  optional int32 limit = 3;
+
+  // Optional pagination offset
+  optional int32 offset = 4;
+}
+
+// Identity provider instance list response
+message IdpInstanceListResp {
+  // List of identity provider instances
+  repeated IdpInstanceSummary instances = 1;
+
+  // Total count of instances (for pagination)
+  int32 total_count = 2;
+}
+
+// Identity provider instance summary (for list responses)
+message IdpInstanceSummary {
+  // Identity provider key
+  string key = 1;
+
+  // Display name
+  string display_name = 2;
+
+  // Provider type
+  IdpProviderType provider_type = 3;
+
+  // Whether configuration is enabled
+  bool enabled = 4;
+
+  // Display order for UI
+  int32 display_order = 5;
+
+  // Created timestamp
+  int64 created = 6;
+
+  // Updated timestamp
+  int64 updated = 7;
+}
+
+// Identity provider instance get request
+message IdpInstanceGetReq {
+  // Identity provider key
+  string key = 1;
+}
+
+// Identity provider instance get response
+message IdpInstanceGetResp {
+  // Identity provider key
+  string key = 1;
+
+  // Display name
+  string display_name = 2;
+
+  // Provider type
+  IdpProviderType provider_type = 3;
+
+  // Whether configuration is enabled
+  bool enabled = 4;
+
+  // Display order for UI
+  int32 display_order = 5;
+
+  // Provider configuration (non-sensitive fields only)
+  string configuration = 6;
+
+  // Created timestamp
+  int64 created = 7;
+
+  // Updated timestamp
+  int64 updated = 8;
+
+  // Created by user
+  string created_by = 9;
+
+  // Updated by user
+  string updated_by = 10;
+}
+
+// Identity provider instance update request
+message IdpInstanceUpdateReq {
+  // Identity provider key
+  string key = 1;
+
+  // Display name
+  string display_name = 2;
+
+  // Whether configuration is enabled
+  bool enabled = 3;
+
+  // Display order for UI
+  int32 display_order = 4;
+
+  // Provider configuration (including sensitive fields)
+  string configuration = 5;
+}
+
+// Identity provider instance update response
+message IdpInstanceUpdateResp {
+  // Success message
+  string message = 1;
+}
+
+// Identity provider instance delete request
+message IdpInstanceDeleteReq {
+  // Identity provider key
+  string key = 1;
+}
+
+// Identity provider instance delete response
+message IdpInstanceDeleteResp {
+  // Success message
+  string message = 1;
 }

--- a/api/mytenant_grpc.pb.go
+++ b/api/mytenant_grpc.pb.go
@@ -22,8 +22,14 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	MyTenant_GetMyPasswordPolicy_FullMethodName    = "/api.MyTenant/GetMyPasswordPolicy"
-	MyTenant_UpdateMyPasswordPolicy_FullMethodName = "/api.MyTenant/UpdateMyPasswordPolicy"
+	MyTenant_GetMyPasswordPolicy_FullMethodName            = "/api.MyTenant/GetMyPasswordPolicy"
+	MyTenant_UpdateMyPasswordPolicy_FullMethodName         = "/api.MyTenant/UpdateMyPasswordPolicy"
+	MyTenant_GetIdentityProviderTypes_FullMethodName       = "/api.MyTenant/GetIdentityProviderTypes"
+	MyTenant_CreateIdentityProviderInstance_FullMethodName = "/api.MyTenant/CreateIdentityProviderInstance"
+	MyTenant_ListIdentityProviderInstances_FullMethodName  = "/api.MyTenant/ListIdentityProviderInstances"
+	MyTenant_GetIdentityProviderInstance_FullMethodName    = "/api.MyTenant/GetIdentityProviderInstance"
+	MyTenant_UpdateIdentityProviderInstance_FullMethodName = "/api.MyTenant/UpdateIdentityProviderInstance"
+	MyTenant_DeleteIdentityProviderInstance_FullMethodName = "/api.MyTenant/DeleteIdentityProviderInstance"
 )
 
 // MyTenantClient is the client API for MyTenant service.
@@ -36,6 +42,18 @@ type MyTenantClient interface {
 	GetMyPasswordPolicy(ctx context.Context, in *MyPasswordPolicyGetReq, opts ...grpc.CallOption) (*MyPasswordPolicyGetResp, error)
 	// Update Password policy configuration
 	UpdateMyPasswordPolicy(ctx context.Context, in *MyPasswordPolicyUpdateReq, opts ...grpc.CallOption) (*MyPasswordPolicyUpdateResp, error)
+	// List supported identity provider types (like Keycloak providers endpoint)
+	GetIdentityProviderTypes(ctx context.Context, in *IdpProvidersReq, opts ...grpc.CallOption) (*IdpProvidersResp, error)
+	// Create identity provider instance (like Keycloak instances endpoint)
+	CreateIdentityProviderInstance(ctx context.Context, in *IdpInstanceCreateReq, opts ...grpc.CallOption) (*IdpInstanceCreateResp, error)
+	// List all configured identity provider instances for the tenant
+	ListIdentityProviderInstances(ctx context.Context, in *IdpInstanceListReq, opts ...grpc.CallOption) (*IdpInstanceListResp, error)
+	// Get identity provider instance configuration (like Keycloak instances endpoint)
+	GetIdentityProviderInstance(ctx context.Context, in *IdpInstanceGetReq, opts ...grpc.CallOption) (*IdpInstanceGetResp, error)
+	// Update identity provider instance configuration (like Keycloak instances endpoint)
+	UpdateIdentityProviderInstance(ctx context.Context, in *IdpInstanceUpdateReq, opts ...grpc.CallOption) (*IdpInstanceUpdateResp, error)
+	// Delete identity provider instance (like Keycloak instances endpoint)
+	DeleteIdentityProviderInstance(ctx context.Context, in *IdpInstanceDeleteReq, opts ...grpc.CallOption) (*IdpInstanceDeleteResp, error)
 }
 
 type myTenantClient struct {
@@ -66,6 +84,66 @@ func (c *myTenantClient) UpdateMyPasswordPolicy(ctx context.Context, in *MyPassw
 	return out, nil
 }
 
+func (c *myTenantClient) GetIdentityProviderTypes(ctx context.Context, in *IdpProvidersReq, opts ...grpc.CallOption) (*IdpProvidersResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(IdpProvidersResp)
+	err := c.cc.Invoke(ctx, MyTenant_GetIdentityProviderTypes_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *myTenantClient) CreateIdentityProviderInstance(ctx context.Context, in *IdpInstanceCreateReq, opts ...grpc.CallOption) (*IdpInstanceCreateResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(IdpInstanceCreateResp)
+	err := c.cc.Invoke(ctx, MyTenant_CreateIdentityProviderInstance_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *myTenantClient) ListIdentityProviderInstances(ctx context.Context, in *IdpInstanceListReq, opts ...grpc.CallOption) (*IdpInstanceListResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(IdpInstanceListResp)
+	err := c.cc.Invoke(ctx, MyTenant_ListIdentityProviderInstances_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *myTenantClient) GetIdentityProviderInstance(ctx context.Context, in *IdpInstanceGetReq, opts ...grpc.CallOption) (*IdpInstanceGetResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(IdpInstanceGetResp)
+	err := c.cc.Invoke(ctx, MyTenant_GetIdentityProviderInstance_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *myTenantClient) UpdateIdentityProviderInstance(ctx context.Context, in *IdpInstanceUpdateReq, opts ...grpc.CallOption) (*IdpInstanceUpdateResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(IdpInstanceUpdateResp)
+	err := c.cc.Invoke(ctx, MyTenant_UpdateIdentityProviderInstance_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *myTenantClient) DeleteIdentityProviderInstance(ctx context.Context, in *IdpInstanceDeleteReq, opts ...grpc.CallOption) (*IdpInstanceDeleteResp, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(IdpInstanceDeleteResp)
+	err := c.cc.Invoke(ctx, MyTenant_DeleteIdentityProviderInstance_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MyTenantServer is the server API for MyTenant service.
 // All implementations must embed UnimplementedMyTenantServer
 // for forward compatibility.
@@ -76,6 +154,18 @@ type MyTenantServer interface {
 	GetMyPasswordPolicy(context.Context, *MyPasswordPolicyGetReq) (*MyPasswordPolicyGetResp, error)
 	// Update Password policy configuration
 	UpdateMyPasswordPolicy(context.Context, *MyPasswordPolicyUpdateReq) (*MyPasswordPolicyUpdateResp, error)
+	// List supported identity provider types (like Keycloak providers endpoint)
+	GetIdentityProviderTypes(context.Context, *IdpProvidersReq) (*IdpProvidersResp, error)
+	// Create identity provider instance (like Keycloak instances endpoint)
+	CreateIdentityProviderInstance(context.Context, *IdpInstanceCreateReq) (*IdpInstanceCreateResp, error)
+	// List all configured identity provider instances for the tenant
+	ListIdentityProviderInstances(context.Context, *IdpInstanceListReq) (*IdpInstanceListResp, error)
+	// Get identity provider instance configuration (like Keycloak instances endpoint)
+	GetIdentityProviderInstance(context.Context, *IdpInstanceGetReq) (*IdpInstanceGetResp, error)
+	// Update identity provider instance configuration (like Keycloak instances endpoint)
+	UpdateIdentityProviderInstance(context.Context, *IdpInstanceUpdateReq) (*IdpInstanceUpdateResp, error)
+	// Delete identity provider instance (like Keycloak instances endpoint)
+	DeleteIdentityProviderInstance(context.Context, *IdpInstanceDeleteReq) (*IdpInstanceDeleteResp, error)
 	mustEmbedUnimplementedMyTenantServer()
 }
 
@@ -91,6 +181,24 @@ func (UnimplementedMyTenantServer) GetMyPasswordPolicy(context.Context, *MyPassw
 }
 func (UnimplementedMyTenantServer) UpdateMyPasswordPolicy(context.Context, *MyPasswordPolicyUpdateReq) (*MyPasswordPolicyUpdateResp, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateMyPasswordPolicy not implemented")
+}
+func (UnimplementedMyTenantServer) GetIdentityProviderTypes(context.Context, *IdpProvidersReq) (*IdpProvidersResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetIdentityProviderTypes not implemented")
+}
+func (UnimplementedMyTenantServer) CreateIdentityProviderInstance(context.Context, *IdpInstanceCreateReq) (*IdpInstanceCreateResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateIdentityProviderInstance not implemented")
+}
+func (UnimplementedMyTenantServer) ListIdentityProviderInstances(context.Context, *IdpInstanceListReq) (*IdpInstanceListResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListIdentityProviderInstances not implemented")
+}
+func (UnimplementedMyTenantServer) GetIdentityProviderInstance(context.Context, *IdpInstanceGetReq) (*IdpInstanceGetResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetIdentityProviderInstance not implemented")
+}
+func (UnimplementedMyTenantServer) UpdateIdentityProviderInstance(context.Context, *IdpInstanceUpdateReq) (*IdpInstanceUpdateResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateIdentityProviderInstance not implemented")
+}
+func (UnimplementedMyTenantServer) DeleteIdentityProviderInstance(context.Context, *IdpInstanceDeleteReq) (*IdpInstanceDeleteResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteIdentityProviderInstance not implemented")
 }
 func (UnimplementedMyTenantServer) mustEmbedUnimplementedMyTenantServer() {}
 func (UnimplementedMyTenantServer) testEmbeddedByValue()                  {}
@@ -149,6 +257,114 @@ func _MyTenant_UpdateMyPasswordPolicy_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MyTenant_GetIdentityProviderTypes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(IdpProvidersReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MyTenantServer).GetIdentityProviderTypes(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MyTenant_GetIdentityProviderTypes_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MyTenantServer).GetIdentityProviderTypes(ctx, req.(*IdpProvidersReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MyTenant_CreateIdentityProviderInstance_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(IdpInstanceCreateReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MyTenantServer).CreateIdentityProviderInstance(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MyTenant_CreateIdentityProviderInstance_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MyTenantServer).CreateIdentityProviderInstance(ctx, req.(*IdpInstanceCreateReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MyTenant_ListIdentityProviderInstances_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(IdpInstanceListReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MyTenantServer).ListIdentityProviderInstances(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MyTenant_ListIdentityProviderInstances_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MyTenantServer).ListIdentityProviderInstances(ctx, req.(*IdpInstanceListReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MyTenant_GetIdentityProviderInstance_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(IdpInstanceGetReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MyTenantServer).GetIdentityProviderInstance(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MyTenant_GetIdentityProviderInstance_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MyTenantServer).GetIdentityProviderInstance(ctx, req.(*IdpInstanceGetReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MyTenant_UpdateIdentityProviderInstance_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(IdpInstanceUpdateReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MyTenantServer).UpdateIdentityProviderInstance(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MyTenant_UpdateIdentityProviderInstance_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MyTenantServer).UpdateIdentityProviderInstance(ctx, req.(*IdpInstanceUpdateReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MyTenant_DeleteIdentityProviderInstance_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(IdpInstanceDeleteReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MyTenantServer).DeleteIdentityProviderInstance(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MyTenant_DeleteIdentityProviderInstance_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MyTenantServer).DeleteIdentityProviderInstance(ctx, req.(*IdpInstanceDeleteReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // MyTenant_ServiceDesc is the grpc.ServiceDesc for MyTenant service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -163,6 +379,30 @@ var MyTenant_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateMyPasswordPolicy",
 			Handler:    _MyTenant_UpdateMyPasswordPolicy_Handler,
+		},
+		{
+			MethodName: "GetIdentityProviderTypes",
+			Handler:    _MyTenant_GetIdentityProviderTypes_Handler,
+		},
+		{
+			MethodName: "CreateIdentityProviderInstance",
+			Handler:    _MyTenant_CreateIdentityProviderInstance_Handler,
+		},
+		{
+			MethodName: "ListIdentityProviderInstances",
+			Handler:    _MyTenant_ListIdentityProviderInstances_Handler,
+		},
+		{
+			MethodName: "GetIdentityProviderInstance",
+			Handler:    _MyTenant_GetIdentityProviderInstance_Handler,
+		},
+		{
+			MethodName: "UpdateIdentityProviderInstance",
+			Handler:    _MyTenant_UpdateIdentityProviderInstance_Handler,
+		},
+		{
+			MethodName: "DeleteIdentityProviderInstance",
+			Handler:    _MyTenant_DeleteIdentityProviderInstance_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/mytenant_grpc.pb.go
+++ b/api/mytenant_grpc.pb.go
@@ -22,14 +22,14 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	MyTenant_GetMyPasswordPolicy_FullMethodName            = "/api.MyTenant/GetMyPasswordPolicy"
-	MyTenant_UpdateMyPasswordPolicy_FullMethodName         = "/api.MyTenant/UpdateMyPasswordPolicy"
-	MyTenant_GetIdentityProviderTypes_FullMethodName       = "/api.MyTenant/GetIdentityProviderTypes"
-	MyTenant_CreateIdentityProviderInstance_FullMethodName = "/api.MyTenant/CreateIdentityProviderInstance"
-	MyTenant_ListIdentityProviderInstances_FullMethodName  = "/api.MyTenant/ListIdentityProviderInstances"
-	MyTenant_GetIdentityProviderInstance_FullMethodName    = "/api.MyTenant/GetIdentityProviderInstance"
-	MyTenant_UpdateIdentityProviderInstance_FullMethodName = "/api.MyTenant/UpdateIdentityProviderInstance"
-	MyTenant_DeleteIdentityProviderInstance_FullMethodName = "/api.MyTenant/DeleteIdentityProviderInstance"
+	MyTenant_GetMyPasswordPolicy_FullMethodName        = "/api.MyTenant/GetMyPasswordPolicy"
+	MyTenant_UpdateMyPasswordPolicy_FullMethodName     = "/api.MyTenant/UpdateMyPasswordPolicy"
+	MyTenant_GetMyIdentityProviderTypes_FullMethodName = "/api.MyTenant/GetMyIdentityProviderTypes"
+	MyTenant_CreateMyIdentityProvider_FullMethodName   = "/api.MyTenant/CreateMyIdentityProvider"
+	MyTenant_ListMyIdentityProviders_FullMethodName    = "/api.MyTenant/ListMyIdentityProviders"
+	MyTenant_GetMyIdentityProvider_FullMethodName      = "/api.MyTenant/GetMyIdentityProvider"
+	MyTenant_UpdateMyIdentityProvider_FullMethodName   = "/api.MyTenant/UpdateMyIdentityProvider"
+	MyTenant_DeleteMyIdentityProvider_FullMethodName   = "/api.MyTenant/DeleteMyIdentityProvider"
 )
 
 // MyTenantClient is the client API for MyTenant service.
@@ -43,17 +43,17 @@ type MyTenantClient interface {
 	// Update Password policy configuration
 	UpdateMyPasswordPolicy(ctx context.Context, in *MyPasswordPolicyUpdateReq, opts ...grpc.CallOption) (*MyPasswordPolicyUpdateResp, error)
 	// List supported identity provider types (like Keycloak providers endpoint)
-	GetIdentityProviderTypes(ctx context.Context, in *IdpProvidersReq, opts ...grpc.CallOption) (*IdpProvidersResp, error)
+	GetMyIdentityProviderTypes(ctx context.Context, in *IdentityProviderTypesGetReq, opts ...grpc.CallOption) (*IdentityProviderTypesGetResp, error)
 	// Create identity provider instance (like Keycloak instances endpoint)
-	CreateIdentityProviderInstance(ctx context.Context, in *IdpInstanceCreateReq, opts ...grpc.CallOption) (*IdpInstanceCreateResp, error)
+	CreateMyIdentityProvider(ctx context.Context, in *MyIdentityProviderCreateReq, opts ...grpc.CallOption) (*MyIdentityProviderCreateResp, error)
 	// List all configured identity provider instances for the tenant
-	ListIdentityProviderInstances(ctx context.Context, in *IdpInstanceListReq, opts ...grpc.CallOption) (*IdpInstanceListResp, error)
-	// Get identity provider instance configuration (like Keycloak instances endpoint)
-	GetIdentityProviderInstance(ctx context.Context, in *IdpInstanceGetReq, opts ...grpc.CallOption) (*IdpInstanceGetResp, error)
-	// Update identity provider instance configuration (like Keycloak instances endpoint)
-	UpdateIdentityProviderInstance(ctx context.Context, in *IdpInstanceUpdateReq, opts ...grpc.CallOption) (*IdpInstanceUpdateResp, error)
-	// Delete identity provider instance (like Keycloak instances endpoint)
-	DeleteIdentityProviderInstance(ctx context.Context, in *IdpInstanceDeleteReq, opts ...grpc.CallOption) (*IdpInstanceDeleteResp, error)
+	ListMyIdentityProviders(ctx context.Context, in *MyIdentityProvidersListReq, opts ...grpc.CallOption) (*MyIdentityProvidersListResp, error)
+	// Get identity provider configuration (like Keycloak instances endpoint)
+	GetMyIdentityProvider(ctx context.Context, in *MyIdentityProviderGetReq, opts ...grpc.CallOption) (*MyIdentityProviderGetResp, error)
+	// Update identity provider configuration (like Keycloak instances endpoint)
+	UpdateMyIdentityProvider(ctx context.Context, in *MyIdentityProviderUpdateReq, opts ...grpc.CallOption) (*MyIdentityProviderUpdateResp, error)
+	// Delete identity provider (like Keycloak instances endpoint)
+	DeleteMyIdentityProvider(ctx context.Context, in *MyIdentityProviderDeleteReq, opts ...grpc.CallOption) (*MyIdentityProviderDeleteResp, error)
 }
 
 type myTenantClient struct {
@@ -84,60 +84,60 @@ func (c *myTenantClient) UpdateMyPasswordPolicy(ctx context.Context, in *MyPassw
 	return out, nil
 }
 
-func (c *myTenantClient) GetIdentityProviderTypes(ctx context.Context, in *IdpProvidersReq, opts ...grpc.CallOption) (*IdpProvidersResp, error) {
+func (c *myTenantClient) GetMyIdentityProviderTypes(ctx context.Context, in *IdentityProviderTypesGetReq, opts ...grpc.CallOption) (*IdentityProviderTypesGetResp, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(IdpProvidersResp)
-	err := c.cc.Invoke(ctx, MyTenant_GetIdentityProviderTypes_FullMethodName, in, out, cOpts...)
+	out := new(IdentityProviderTypesGetResp)
+	err := c.cc.Invoke(ctx, MyTenant_GetMyIdentityProviderTypes_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *myTenantClient) CreateIdentityProviderInstance(ctx context.Context, in *IdpInstanceCreateReq, opts ...grpc.CallOption) (*IdpInstanceCreateResp, error) {
+func (c *myTenantClient) CreateMyIdentityProvider(ctx context.Context, in *MyIdentityProviderCreateReq, opts ...grpc.CallOption) (*MyIdentityProviderCreateResp, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(IdpInstanceCreateResp)
-	err := c.cc.Invoke(ctx, MyTenant_CreateIdentityProviderInstance_FullMethodName, in, out, cOpts...)
+	out := new(MyIdentityProviderCreateResp)
+	err := c.cc.Invoke(ctx, MyTenant_CreateMyIdentityProvider_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *myTenantClient) ListIdentityProviderInstances(ctx context.Context, in *IdpInstanceListReq, opts ...grpc.CallOption) (*IdpInstanceListResp, error) {
+func (c *myTenantClient) ListMyIdentityProviders(ctx context.Context, in *MyIdentityProvidersListReq, opts ...grpc.CallOption) (*MyIdentityProvidersListResp, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(IdpInstanceListResp)
-	err := c.cc.Invoke(ctx, MyTenant_ListIdentityProviderInstances_FullMethodName, in, out, cOpts...)
+	out := new(MyIdentityProvidersListResp)
+	err := c.cc.Invoke(ctx, MyTenant_ListMyIdentityProviders_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *myTenantClient) GetIdentityProviderInstance(ctx context.Context, in *IdpInstanceGetReq, opts ...grpc.CallOption) (*IdpInstanceGetResp, error) {
+func (c *myTenantClient) GetMyIdentityProvider(ctx context.Context, in *MyIdentityProviderGetReq, opts ...grpc.CallOption) (*MyIdentityProviderGetResp, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(IdpInstanceGetResp)
-	err := c.cc.Invoke(ctx, MyTenant_GetIdentityProviderInstance_FullMethodName, in, out, cOpts...)
+	out := new(MyIdentityProviderGetResp)
+	err := c.cc.Invoke(ctx, MyTenant_GetMyIdentityProvider_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *myTenantClient) UpdateIdentityProviderInstance(ctx context.Context, in *IdpInstanceUpdateReq, opts ...grpc.CallOption) (*IdpInstanceUpdateResp, error) {
+func (c *myTenantClient) UpdateMyIdentityProvider(ctx context.Context, in *MyIdentityProviderUpdateReq, opts ...grpc.CallOption) (*MyIdentityProviderUpdateResp, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(IdpInstanceUpdateResp)
-	err := c.cc.Invoke(ctx, MyTenant_UpdateIdentityProviderInstance_FullMethodName, in, out, cOpts...)
+	out := new(MyIdentityProviderUpdateResp)
+	err := c.cc.Invoke(ctx, MyTenant_UpdateMyIdentityProvider_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *myTenantClient) DeleteIdentityProviderInstance(ctx context.Context, in *IdpInstanceDeleteReq, opts ...grpc.CallOption) (*IdpInstanceDeleteResp, error) {
+func (c *myTenantClient) DeleteMyIdentityProvider(ctx context.Context, in *MyIdentityProviderDeleteReq, opts ...grpc.CallOption) (*MyIdentityProviderDeleteResp, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(IdpInstanceDeleteResp)
-	err := c.cc.Invoke(ctx, MyTenant_DeleteIdentityProviderInstance_FullMethodName, in, out, cOpts...)
+	out := new(MyIdentityProviderDeleteResp)
+	err := c.cc.Invoke(ctx, MyTenant_DeleteMyIdentityProvider_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -155,17 +155,17 @@ type MyTenantServer interface {
 	// Update Password policy configuration
 	UpdateMyPasswordPolicy(context.Context, *MyPasswordPolicyUpdateReq) (*MyPasswordPolicyUpdateResp, error)
 	// List supported identity provider types (like Keycloak providers endpoint)
-	GetIdentityProviderTypes(context.Context, *IdpProvidersReq) (*IdpProvidersResp, error)
+	GetMyIdentityProviderTypes(context.Context, *IdentityProviderTypesGetReq) (*IdentityProviderTypesGetResp, error)
 	// Create identity provider instance (like Keycloak instances endpoint)
-	CreateIdentityProviderInstance(context.Context, *IdpInstanceCreateReq) (*IdpInstanceCreateResp, error)
+	CreateMyIdentityProvider(context.Context, *MyIdentityProviderCreateReq) (*MyIdentityProviderCreateResp, error)
 	// List all configured identity provider instances for the tenant
-	ListIdentityProviderInstances(context.Context, *IdpInstanceListReq) (*IdpInstanceListResp, error)
-	// Get identity provider instance configuration (like Keycloak instances endpoint)
-	GetIdentityProviderInstance(context.Context, *IdpInstanceGetReq) (*IdpInstanceGetResp, error)
-	// Update identity provider instance configuration (like Keycloak instances endpoint)
-	UpdateIdentityProviderInstance(context.Context, *IdpInstanceUpdateReq) (*IdpInstanceUpdateResp, error)
-	// Delete identity provider instance (like Keycloak instances endpoint)
-	DeleteIdentityProviderInstance(context.Context, *IdpInstanceDeleteReq) (*IdpInstanceDeleteResp, error)
+	ListMyIdentityProviders(context.Context, *MyIdentityProvidersListReq) (*MyIdentityProvidersListResp, error)
+	// Get identity provider configuration (like Keycloak instances endpoint)
+	GetMyIdentityProvider(context.Context, *MyIdentityProviderGetReq) (*MyIdentityProviderGetResp, error)
+	// Update identity provider configuration (like Keycloak instances endpoint)
+	UpdateMyIdentityProvider(context.Context, *MyIdentityProviderUpdateReq) (*MyIdentityProviderUpdateResp, error)
+	// Delete identity provider (like Keycloak instances endpoint)
+	DeleteMyIdentityProvider(context.Context, *MyIdentityProviderDeleteReq) (*MyIdentityProviderDeleteResp, error)
 	mustEmbedUnimplementedMyTenantServer()
 }
 
@@ -182,23 +182,23 @@ func (UnimplementedMyTenantServer) GetMyPasswordPolicy(context.Context, *MyPassw
 func (UnimplementedMyTenantServer) UpdateMyPasswordPolicy(context.Context, *MyPasswordPolicyUpdateReq) (*MyPasswordPolicyUpdateResp, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateMyPasswordPolicy not implemented")
 }
-func (UnimplementedMyTenantServer) GetIdentityProviderTypes(context.Context, *IdpProvidersReq) (*IdpProvidersResp, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetIdentityProviderTypes not implemented")
+func (UnimplementedMyTenantServer) GetMyIdentityProviderTypes(context.Context, *IdentityProviderTypesGetReq) (*IdentityProviderTypesGetResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetMyIdentityProviderTypes not implemented")
 }
-func (UnimplementedMyTenantServer) CreateIdentityProviderInstance(context.Context, *IdpInstanceCreateReq) (*IdpInstanceCreateResp, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method CreateIdentityProviderInstance not implemented")
+func (UnimplementedMyTenantServer) CreateMyIdentityProvider(context.Context, *MyIdentityProviderCreateReq) (*MyIdentityProviderCreateResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateMyIdentityProvider not implemented")
 }
-func (UnimplementedMyTenantServer) ListIdentityProviderInstances(context.Context, *IdpInstanceListReq) (*IdpInstanceListResp, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method ListIdentityProviderInstances not implemented")
+func (UnimplementedMyTenantServer) ListMyIdentityProviders(context.Context, *MyIdentityProvidersListReq) (*MyIdentityProvidersListResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListMyIdentityProviders not implemented")
 }
-func (UnimplementedMyTenantServer) GetIdentityProviderInstance(context.Context, *IdpInstanceGetReq) (*IdpInstanceGetResp, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetIdentityProviderInstance not implemented")
+func (UnimplementedMyTenantServer) GetMyIdentityProvider(context.Context, *MyIdentityProviderGetReq) (*MyIdentityProviderGetResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetMyIdentityProvider not implemented")
 }
-func (UnimplementedMyTenantServer) UpdateIdentityProviderInstance(context.Context, *IdpInstanceUpdateReq) (*IdpInstanceUpdateResp, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method UpdateIdentityProviderInstance not implemented")
+func (UnimplementedMyTenantServer) UpdateMyIdentityProvider(context.Context, *MyIdentityProviderUpdateReq) (*MyIdentityProviderUpdateResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateMyIdentityProvider not implemented")
 }
-func (UnimplementedMyTenantServer) DeleteIdentityProviderInstance(context.Context, *IdpInstanceDeleteReq) (*IdpInstanceDeleteResp, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method DeleteIdentityProviderInstance not implemented")
+func (UnimplementedMyTenantServer) DeleteMyIdentityProvider(context.Context, *MyIdentityProviderDeleteReq) (*MyIdentityProviderDeleteResp, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteMyIdentityProvider not implemented")
 }
 func (UnimplementedMyTenantServer) mustEmbedUnimplementedMyTenantServer() {}
 func (UnimplementedMyTenantServer) testEmbeddedByValue()                  {}
@@ -257,110 +257,110 @@ func _MyTenant_UpdateMyPasswordPolicy_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
-func _MyTenant_GetIdentityProviderTypes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(IdpProvidersReq)
+func _MyTenant_GetMyIdentityProviderTypes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(IdentityProviderTypesGetReq)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MyTenantServer).GetIdentityProviderTypes(ctx, in)
+		return srv.(MyTenantServer).GetMyIdentityProviderTypes(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: MyTenant_GetIdentityProviderTypes_FullMethodName,
+		FullMethod: MyTenant_GetMyIdentityProviderTypes_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MyTenantServer).GetIdentityProviderTypes(ctx, req.(*IdpProvidersReq))
+		return srv.(MyTenantServer).GetMyIdentityProviderTypes(ctx, req.(*IdentityProviderTypesGetReq))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _MyTenant_CreateIdentityProviderInstance_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(IdpInstanceCreateReq)
+func _MyTenant_CreateMyIdentityProvider_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MyIdentityProviderCreateReq)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MyTenantServer).CreateIdentityProviderInstance(ctx, in)
+		return srv.(MyTenantServer).CreateMyIdentityProvider(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: MyTenant_CreateIdentityProviderInstance_FullMethodName,
+		FullMethod: MyTenant_CreateMyIdentityProvider_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MyTenantServer).CreateIdentityProviderInstance(ctx, req.(*IdpInstanceCreateReq))
+		return srv.(MyTenantServer).CreateMyIdentityProvider(ctx, req.(*MyIdentityProviderCreateReq))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _MyTenant_ListIdentityProviderInstances_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(IdpInstanceListReq)
+func _MyTenant_ListMyIdentityProviders_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MyIdentityProvidersListReq)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MyTenantServer).ListIdentityProviderInstances(ctx, in)
+		return srv.(MyTenantServer).ListMyIdentityProviders(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: MyTenant_ListIdentityProviderInstances_FullMethodName,
+		FullMethod: MyTenant_ListMyIdentityProviders_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MyTenantServer).ListIdentityProviderInstances(ctx, req.(*IdpInstanceListReq))
+		return srv.(MyTenantServer).ListMyIdentityProviders(ctx, req.(*MyIdentityProvidersListReq))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _MyTenant_GetIdentityProviderInstance_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(IdpInstanceGetReq)
+func _MyTenant_GetMyIdentityProvider_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MyIdentityProviderGetReq)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MyTenantServer).GetIdentityProviderInstance(ctx, in)
+		return srv.(MyTenantServer).GetMyIdentityProvider(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: MyTenant_GetIdentityProviderInstance_FullMethodName,
+		FullMethod: MyTenant_GetMyIdentityProvider_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MyTenantServer).GetIdentityProviderInstance(ctx, req.(*IdpInstanceGetReq))
+		return srv.(MyTenantServer).GetMyIdentityProvider(ctx, req.(*MyIdentityProviderGetReq))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _MyTenant_UpdateIdentityProviderInstance_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(IdpInstanceUpdateReq)
+func _MyTenant_UpdateMyIdentityProvider_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MyIdentityProviderUpdateReq)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MyTenantServer).UpdateIdentityProviderInstance(ctx, in)
+		return srv.(MyTenantServer).UpdateMyIdentityProvider(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: MyTenant_UpdateIdentityProviderInstance_FullMethodName,
+		FullMethod: MyTenant_UpdateMyIdentityProvider_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MyTenantServer).UpdateIdentityProviderInstance(ctx, req.(*IdpInstanceUpdateReq))
+		return srv.(MyTenantServer).UpdateMyIdentityProvider(ctx, req.(*MyIdentityProviderUpdateReq))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _MyTenant_DeleteIdentityProviderInstance_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(IdpInstanceDeleteReq)
+func _MyTenant_DeleteMyIdentityProvider_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MyIdentityProviderDeleteReq)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MyTenantServer).DeleteIdentityProviderInstance(ctx, in)
+		return srv.(MyTenantServer).DeleteMyIdentityProvider(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: MyTenant_DeleteIdentityProviderInstance_FullMethodName,
+		FullMethod: MyTenant_DeleteMyIdentityProvider_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MyTenantServer).DeleteIdentityProviderInstance(ctx, req.(*IdpInstanceDeleteReq))
+		return srv.(MyTenantServer).DeleteMyIdentityProvider(ctx, req.(*MyIdentityProviderDeleteReq))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -381,28 +381,28 @@ var MyTenant_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _MyTenant_UpdateMyPasswordPolicy_Handler,
 		},
 		{
-			MethodName: "GetIdentityProviderTypes",
-			Handler:    _MyTenant_GetIdentityProviderTypes_Handler,
+			MethodName: "GetMyIdentityProviderTypes",
+			Handler:    _MyTenant_GetMyIdentityProviderTypes_Handler,
 		},
 		{
-			MethodName: "CreateIdentityProviderInstance",
-			Handler:    _MyTenant_CreateIdentityProviderInstance_Handler,
+			MethodName: "CreateMyIdentityProvider",
+			Handler:    _MyTenant_CreateMyIdentityProvider_Handler,
 		},
 		{
-			MethodName: "ListIdentityProviderInstances",
-			Handler:    _MyTenant_ListIdentityProviderInstances_Handler,
+			MethodName: "ListMyIdentityProviders",
+			Handler:    _MyTenant_ListMyIdentityProviders_Handler,
 		},
 		{
-			MethodName: "GetIdentityProviderInstance",
-			Handler:    _MyTenant_GetIdentityProviderInstance_Handler,
+			MethodName: "GetMyIdentityProvider",
+			Handler:    _MyTenant_GetMyIdentityProvider_Handler,
 		},
 		{
-			MethodName: "UpdateIdentityProviderInstance",
-			Handler:    _MyTenant_UpdateIdentityProviderInstance_Handler,
+			MethodName: "UpdateMyIdentityProvider",
+			Handler:    _MyTenant_UpdateMyIdentityProvider_Handler,
 		},
 		{
-			MethodName: "DeleteIdentityProviderInstance",
-			Handler:    _MyTenant_DeleteIdentityProviderInstance_Handler,
+			MethodName: "DeleteMyIdentityProvider",
+			Handler:    _MyTenant_DeleteMyIdentityProvider_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/swagger/apidocs.swagger.json
+++ b/api/swagger/apidocs.swagger.json
@@ -1366,14 +1366,14 @@
       }
     },
     "/api/mytenant/v1/identity-provider": {
-      "get": {
-        "summary": "List all configured identity provider instances for the tenant",
-        "operationId": "MyTenant_ListIdentityProviderInstances",
+      "post": {
+        "summary": "Create identity provider instance (like Keycloak instances endpoint)",
+        "operationId": "MyTenant_CreateMyIdentityProvider",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiIdpInstanceListResp"
+              "$ref": "#/definitions/apiMyIdentityProviderCreateResp"
             }
           },
           "default": {
@@ -1385,17 +1385,171 @@
         },
         "parameters": [
           {
-            "name": "providerType",
-            "description": "Optional filter by provider type",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiMyIdentityProviderCreateReq"
+            }
+          }
+        ],
+        "tags": [
+          "MyTenant"
+        ]
+      }
+    },
+    "/api/mytenant/v1/identity-provider-types": {
+      "get": {
+        "summary": "List supported identity provider types (like Keycloak providers endpoint)",
+        "operationId": "MyTenant_GetMyIdentityProviderTypes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiIdentityProviderTypesGetResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "MyTenant"
+        ]
+      }
+    },
+    "/api/mytenant/v1/identity-provider/{key}": {
+      "get": {
+        "summary": "Get identity provider configuration (like Keycloak instances endpoint)",
+        "operationId": "MyTenant_GetMyIdentityProvider",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiMyIdentityProviderGetResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "key",
+            "description": "Identity provider key",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "MyTenant"
+        ]
+      },
+      "delete": {
+        "summary": "Delete identity provider (like Keycloak instances endpoint)",
+        "operationId": "MyTenant_DeleteMyIdentityProvider",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiMyIdentityProviderDeleteResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "key",
+            "description": "Identity provider key",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "MyTenant"
+        ]
+      },
+      "put": {
+        "summary": "Update identity provider configuration (like Keycloak instances endpoint)",
+        "operationId": "MyTenant_UpdateMyIdentityProvider",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiMyIdentityProviderUpdateResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "key",
+            "description": "Identity provider key",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MyTenantUpdateMyIdentityProviderBody"
+            }
+          }
+        ],
+        "tags": [
+          "MyTenant"
+        ]
+      }
+    },
+    "/api/mytenant/v1/identity-providers": {
+      "get": {
+        "summary": "List all configured identity provider instances for the tenant",
+        "operationId": "MyTenant_ListMyIdentityProviders",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiMyIdentityProvidersListResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "type",
+            "description": "Optional filter by provider type\n\n - IdentityProviderUnspecified: Unspecified IDP\n - Google: Identity Provider - Google\n - Microsoft: Identity Provider - Microsoft",
             "in": "query",
             "required": false,
             "type": "string",
             "enum": [
               "IdentityProviderUnspecified",
               "Google",
-              "Microsoft",
-              "OIDC",
-              "SAML"
+              "Microsoft"
             ],
             "default": "IdentityProviderUnspecified"
           },
@@ -1421,177 +1575,6 @@
             "required": false,
             "type": "integer",
             "format": "int32"
-          }
-        ],
-        "tags": [
-          "MyTenant"
-        ]
-      },
-      "post": {
-        "summary": "Create identity provider instance (like Keycloak instances endpoint)",
-        "operationId": "MyTenant_CreateIdentityProviderInstance",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/apiIdpInstanceCreateResp"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/apiIdpInstanceCreateReq"
-            }
-          }
-        ],
-        "tags": [
-          "MyTenant"
-        ]
-      }
-    },
-    "/api/mytenant/v1/identity-provider-types": {
-      "get": {
-        "summary": "List supported identity provider types (like Keycloak providers endpoint)",
-        "operationId": "MyTenant_GetIdentityProviderTypes",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/apiIdpProvidersResp"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "providerType",
-            "description": "Optional filter by provider type",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "enum": [
-              "IdentityProviderUnspecified",
-              "Google",
-              "Microsoft",
-              "OIDC",
-              "SAML"
-            ],
-            "default": "IdentityProviderUnspecified"
-          }
-        ],
-        "tags": [
-          "MyTenant"
-        ]
-      }
-    },
-    "/api/mytenant/v1/identity-provider/{key}": {
-      "get": {
-        "summary": "Get identity provider instance configuration (like Keycloak instances endpoint)",
-        "operationId": "MyTenant_GetIdentityProviderInstance",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/apiIdpInstanceGetResp"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "key",
-            "description": "Identity provider key",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "MyTenant"
-        ]
-      },
-      "delete": {
-        "summary": "Delete identity provider instance (like Keycloak instances endpoint)",
-        "operationId": "MyTenant_DeleteIdentityProviderInstance",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/apiIdpInstanceDeleteResp"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "key",
-            "description": "Identity provider key",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "tags": [
-          "MyTenant"
-        ]
-      },
-      "put": {
-        "summary": "Update identity provider instance configuration (like Keycloak instances endpoint)",
-        "operationId": "MyTenant_UpdateIdentityProviderInstance",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/apiIdpInstanceUpdateResp"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "key",
-            "description": "Identity provider key",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/MyTenantUpdateIdentityProviderInstanceBody"
-            }
           }
         ],
         "tags": [
@@ -2286,10 +2269,10 @@
       },
       "title": "request for update of an existing customer"
     },
-    "MyTenantUpdateIdentityProviderInstanceBody": {
+    "MyTenantUpdateMyIdentityProviderBody": {
       "type": "object",
       "properties": {
-        "displayName": {
+        "dispName": {
           "type": "string",
           "title": "Display name"
         },
@@ -2297,17 +2280,20 @@
           "type": "boolean",
           "title": "Whether configuration is enabled"
         },
-        "displayOrder": {
-          "type": "integer",
-          "format": "int32",
-          "title": "Display order for UI"
+        "type": {
+          "$ref": "#/definitions/apiIdentityProviderDefsType",
+          "title": "Provider type"
         },
-        "configuration": {
-          "type": "string",
-          "title": "Provider configuration (including sensitive fields)"
+        "google": {
+          "$ref": "#/definitions/apiGoogleIDPConfig",
+          "title": "configuration for Google Identity Provider"
+        },
+        "microsoft": {
+          "$ref": "#/definitions/apiMicrosoftIDPConfig",
+          "title": "configuration for Microsoft Identity Provider"
         }
       },
-      "title": "Identity provider instance update request"
+      "title": "Identity provider update request"
     },
     "OrgUnitUpdateOrgUnitBody": {
       "type": "object",
@@ -2567,265 +2553,73 @@
     "apiDefaultOrgUnitResp": {
       "type": "object"
     },
-    "apiIdpConfigField": {
+    "apiGoogleIDPConfig": {
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string"
+        "clientId": {
+          "type": "string",
+          "title": "client id from google SSO config, where controller\nis enabled as client"
         },
-        "type": {
-          "type": "string"
+        "clientSecret": {
+          "type": "string",
+          "title": "client secret to validate ourself with google"
         },
-        "required": {
-          "type": "boolean"
-        },
-        "sensitive": {
-          "type": "boolean"
-        },
-        "description": {
-          "type": "string"
-        },
-        "defaultValue": {
-          "type": "string"
-        },
-        "validation": {
-          "type": "string"
+        "hostedDomain": {
+          "type": "string",
+          "title": "Hosted Domain for allowing users only from specific domain"
         }
-      },
-      "title": "Configuration field metadata for validation"
+      }
     },
-    "apiIdpInstanceCreateReq": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string",
-          "title": "Identity provider key (unique per tenant)"
-        },
-        "displayName": {
-          "type": "string",
-          "title": "Display name"
-        },
-        "providerType": {
-          "$ref": "#/definitions/apiIdpProviderType",
-          "title": "Provider type"
-        },
-        "enabled": {
-          "type": "boolean",
-          "title": "Whether configuration is enabled"
-        },
-        "displayOrder": {
-          "type": "integer",
-          "format": "int32",
-          "title": "Display order for UI"
-        },
-        "configuration": {
-          "type": "string",
-          "title": "Provider configuration (including sensitive fields)"
-        }
-      },
-      "title": "Identity provider instance create request"
-    },
-    "apiIdpInstanceCreateResp": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string",
-          "title": "Created identity provider key"
-        },
-        "message": {
-          "type": "string",
-          "title": "Success message"
-        }
-      },
-      "title": "Identity provider instance create response"
-    },
-    "apiIdpInstanceDeleteResp": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string",
-          "title": "Success message"
-        }
-      },
-      "title": "Identity provider instance delete response"
-    },
-    "apiIdpInstanceGetResp": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string",
-          "title": "Identity provider key"
-        },
-        "displayName": {
-          "type": "string",
-          "title": "Display name"
-        },
-        "providerType": {
-          "$ref": "#/definitions/apiIdpProviderType",
-          "title": "Provider type"
-        },
-        "enabled": {
-          "type": "boolean",
-          "title": "Whether configuration is enabled"
-        },
-        "displayOrder": {
-          "type": "integer",
-          "format": "int32",
-          "title": "Display order for UI"
-        },
-        "configuration": {
-          "type": "string",
-          "title": "Provider configuration (non-sensitive fields only)"
-        },
-        "created": {
-          "type": "string",
-          "format": "int64",
-          "title": "Created timestamp"
-        },
-        "updated": {
-          "type": "string",
-          "format": "int64",
-          "title": "Updated timestamp"
-        },
-        "createdBy": {
-          "type": "string",
-          "title": "Created by user"
-        },
-        "updatedBy": {
-          "type": "string",
-          "title": "Updated by user"
-        }
-      },
-      "title": "Identity provider instance get response"
-    },
-    "apiIdpInstanceListResp": {
-      "type": "object",
-      "properties": {
-        "instances": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/apiIdpInstanceSummary"
-          },
-          "title": "List of identity provider instances"
-        },
-        "totalCount": {
-          "type": "integer",
-          "format": "int32",
-          "title": "Total count of instances (for pagination)"
-        }
-      },
-      "title": "Identity provider instance list response"
-    },
-    "apiIdpInstanceSummary": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string",
-          "title": "Identity provider key"
-        },
-        "displayName": {
-          "type": "string",
-          "title": "Display name"
-        },
-        "providerType": {
-          "$ref": "#/definitions/apiIdpProviderType",
-          "title": "Provider type"
-        },
-        "enabled": {
-          "type": "boolean",
-          "title": "Whether configuration is enabled"
-        },
-        "displayOrder": {
-          "type": "integer",
-          "format": "int32",
-          "title": "Display order for UI"
-        },
-        "created": {
-          "type": "string",
-          "format": "int64",
-          "title": "Created timestamp"
-        },
-        "updated": {
-          "type": "string",
-          "format": "int64",
-          "title": "Updated timestamp"
-        }
-      },
-      "title": "Identity provider instance summary (for list responses)"
-    },
-    "apiIdpInstanceUpdateResp": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string",
-          "title": "Success message"
-        }
-      },
-      "title": "Identity provider instance update response"
-    },
-    "apiIdpProviderMetadata": {
-      "type": "object",
-      "properties": {
-        "providerType": {
-          "$ref": "#/definitions/apiIdpProviderType"
-        },
-        "displayName": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "configFields": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/apiIdpConfigField"
-          }
-        },
-        "supportedScopes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "defaultScopes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "documentation": {
-          "type": "string"
-        }
-      },
-      "title": "Provider metadata"
-    },
-    "apiIdpProviderType": {
+    "apiIdentityProviderDefsType": {
       "type": "string",
       "enum": [
         "IdentityProviderUnspecified",
         "Google",
-        "Microsoft",
-        "OIDC",
-        "SAML"
+        "Microsoft"
       ],
       "default": "IdentityProviderUnspecified",
+      "description": "- IdentityProviderUnspecified: Unspecified IDP\n - Google: Identity Provider - Google\n - Microsoft: Identity Provider - Microsoft",
       "title": "Identity Provider types"
     },
-    "apiIdpProvidersResp": {
+    "apiIdentityProviderTypesGetResp": {
       "type": "object",
       "properties": {
         "providers": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiIdpProviderMetadata"
+            "$ref": "#/definitions/apiIdentityProviderTypesListEntry"
           },
-          "title": "Available provider types and their metadata"
+          "title": "Available provider types"
         }
       },
       "title": "Identity provider providers response"
+    },
+    "apiIdentityProviderTypesListEntry": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "title": "type value for the list entry"
+        }
+      }
+    },
+    "apiMicrosoftIDPConfig": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "title": "client id from microsoft SSO config, where controller\nis enabled as client"
+        },
+        "clientSecret": {
+          "type": "string",
+          "title": "client secret to validate ourself with microsoft"
+        },
+        "tenantId": {
+          "type": "string",
+          "title": "tenant id to ensure allowing users only from specific\nmicrosoft tenant"
+        }
+      }
     },
     "apiMyAzsListEntry": {
       "type": "object",
@@ -2852,6 +2646,133 @@
           "title": "list of available azs for the tenant\nunder a region"
         }
       }
+    },
+    "apiMyIdentityProviderCreateReq": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "title": "Identity provider key (unique per tenant), also used for\nhosting SSO broker endpoint"
+        },
+        "dispName": {
+          "type": "string",
+          "title": "Display name"
+        },
+        "type": {
+          "$ref": "#/definitions/apiIdentityProviderDefsType",
+          "title": "Provider type"
+        },
+        "enabled": {
+          "type": "boolean",
+          "title": "Whether configuration is enabled"
+        },
+        "google": {
+          "$ref": "#/definitions/apiGoogleIDPConfig",
+          "title": "configuration for Google Identity Provider"
+        },
+        "microsoft": {
+          "$ref": "#/definitions/apiMicrosoftIDPConfig",
+          "title": "configuration for Microsoft Identity Provider"
+        }
+      },
+      "title": "Identity provider create request"
+    },
+    "apiMyIdentityProviderCreateResp": {
+      "type": "object",
+      "title": "Identity provider create response"
+    },
+    "apiMyIdentityProviderDeleteResp": {
+      "type": "object",
+      "title": "Identity provider delete response"
+    },
+    "apiMyIdentityProviderGetResp": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "title": "Identity provider key"
+        },
+        "dispName": {
+          "type": "string",
+          "title": "Display name"
+        },
+        "type": {
+          "$ref": "#/definitions/apiIdentityProviderDefsType",
+          "title": "Provider type"
+        },
+        "enabled": {
+          "type": "boolean",
+          "title": "Whether configuration is enabled"
+        },
+        "created": {
+          "type": "string",
+          "format": "int64",
+          "title": "Created timestamp"
+        },
+        "createdBy": {
+          "type": "string",
+          "title": "Created by user"
+        },
+        "google": {
+          "$ref": "#/definitions/apiGoogleIDPConfig",
+          "title": "configuration for Google Identity Provider"
+        },
+        "microsoft": {
+          "$ref": "#/definitions/apiMicrosoftIDPConfig",
+          "title": "configuration for Microsoft Identity Provider"
+        }
+      },
+      "title": "Identity provider get response"
+    },
+    "apiMyIdentityProviderUpdateResp": {
+      "type": "object",
+      "title": "Identity provider update response"
+    },
+    "apiMyIdentityProvidersListEntry": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "title": "Identity provider key"
+        },
+        "dispName": {
+          "type": "string",
+          "title": "Display name"
+        },
+        "type": {
+          "$ref": "#/definitions/apiIdentityProviderDefsType",
+          "title": "Provider type"
+        },
+        "enabled": {
+          "type": "boolean",
+          "title": "Whether configuration is enabled"
+        },
+        "created": {
+          "type": "string",
+          "format": "int64",
+          "title": "Created timestamp"
+        }
+      },
+      "title": "Identity provider list entry"
+    },
+    "apiMyIdentityProvidersListResp": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Count of IDP available"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiMyIdentityProvidersListEntry"
+          },
+          "title": "List of identity providers"
+        }
+      },
+      "title": "Identity provider instance list response"
     },
     "apiMyInfoGetResp": {
       "type": "object",

--- a/api/swagger/apidocs.swagger.json
+++ b/api/swagger/apidocs.swagger.json
@@ -1365,6 +1365,240 @@
         ]
       }
     },
+    "/api/mytenant/v1/identity-provider": {
+      "get": {
+        "summary": "List all configured identity provider instances for the tenant",
+        "operationId": "MyTenant_ListIdentityProviderInstances",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiIdpInstanceListResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "providerType",
+            "description": "Optional filter by provider type",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "IdentityProviderUnspecified",
+              "Google",
+              "Microsoft",
+              "OIDC",
+              "SAML"
+            ],
+            "default": "IdentityProviderUnspecified"
+          },
+          {
+            "name": "enabled",
+            "description": "Optional filter by enabled status",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "limit",
+            "description": "Optional pagination limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "offset",
+            "description": "Optional pagination offset",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "tags": [
+          "MyTenant"
+        ]
+      },
+      "post": {
+        "summary": "Create identity provider instance (like Keycloak instances endpoint)",
+        "operationId": "MyTenant_CreateIdentityProviderInstance",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiIdpInstanceCreateResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiIdpInstanceCreateReq"
+            }
+          }
+        ],
+        "tags": [
+          "MyTenant"
+        ]
+      }
+    },
+    "/api/mytenant/v1/identity-provider-types": {
+      "get": {
+        "summary": "List supported identity provider types (like Keycloak providers endpoint)",
+        "operationId": "MyTenant_GetIdentityProviderTypes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiIdpProvidersResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "providerType",
+            "description": "Optional filter by provider type",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "IdentityProviderUnspecified",
+              "Google",
+              "Microsoft",
+              "OIDC",
+              "SAML"
+            ],
+            "default": "IdentityProviderUnspecified"
+          }
+        ],
+        "tags": [
+          "MyTenant"
+        ]
+      }
+    },
+    "/api/mytenant/v1/identity-provider/{key}": {
+      "get": {
+        "summary": "Get identity provider instance configuration (like Keycloak instances endpoint)",
+        "operationId": "MyTenant_GetIdentityProviderInstance",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiIdpInstanceGetResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "key",
+            "description": "Identity provider key",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "MyTenant"
+        ]
+      },
+      "delete": {
+        "summary": "Delete identity provider instance (like Keycloak instances endpoint)",
+        "operationId": "MyTenant_DeleteIdentityProviderInstance",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiIdpInstanceDeleteResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "key",
+            "description": "Identity provider key",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "MyTenant"
+        ]
+      },
+      "put": {
+        "summary": "Update identity provider instance configuration (like Keycloak instances endpoint)",
+        "operationId": "MyTenant_UpdateIdentityProviderInstance",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiIdpInstanceUpdateResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "key",
+            "description": "Identity provider key",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MyTenantUpdateIdentityProviderInstanceBody"
+            }
+          }
+        ],
+        "tags": [
+          "MyTenant"
+        ]
+      }
+    },
     "/api/mytenant/v1/ou": {
       "post": {
         "summary": "Create new org unit for my tenant",
@@ -2052,6 +2286,29 @@
       },
       "title": "request for update of an existing customer"
     },
+    "MyTenantUpdateIdentityProviderInstanceBody": {
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "title": "Display name"
+        },
+        "enabled": {
+          "type": "boolean",
+          "title": "Whether configuration is enabled"
+        },
+        "displayOrder": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Display order for UI"
+        },
+        "configuration": {
+          "type": "string",
+          "title": "Provider configuration (including sensitive fields)"
+        }
+      },
+      "title": "Identity provider instance update request"
+    },
     "OrgUnitUpdateOrgUnitBody": {
       "type": "object",
       "properties": {
@@ -2309,6 +2566,266 @@
     },
     "apiDefaultOrgUnitResp": {
       "type": "object"
+    },
+    "apiIdpConfigField": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "sensitive": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "defaultValue": {
+          "type": "string"
+        },
+        "validation": {
+          "type": "string"
+        }
+      },
+      "title": "Configuration field metadata for validation"
+    },
+    "apiIdpInstanceCreateReq": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "title": "Identity provider key (unique per tenant)"
+        },
+        "displayName": {
+          "type": "string",
+          "title": "Display name"
+        },
+        "providerType": {
+          "$ref": "#/definitions/apiIdpProviderType",
+          "title": "Provider type"
+        },
+        "enabled": {
+          "type": "boolean",
+          "title": "Whether configuration is enabled"
+        },
+        "displayOrder": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Display order for UI"
+        },
+        "configuration": {
+          "type": "string",
+          "title": "Provider configuration (including sensitive fields)"
+        }
+      },
+      "title": "Identity provider instance create request"
+    },
+    "apiIdpInstanceCreateResp": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "title": "Created identity provider key"
+        },
+        "message": {
+          "type": "string",
+          "title": "Success message"
+        }
+      },
+      "title": "Identity provider instance create response"
+    },
+    "apiIdpInstanceDeleteResp": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "title": "Success message"
+        }
+      },
+      "title": "Identity provider instance delete response"
+    },
+    "apiIdpInstanceGetResp": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "title": "Identity provider key"
+        },
+        "displayName": {
+          "type": "string",
+          "title": "Display name"
+        },
+        "providerType": {
+          "$ref": "#/definitions/apiIdpProviderType",
+          "title": "Provider type"
+        },
+        "enabled": {
+          "type": "boolean",
+          "title": "Whether configuration is enabled"
+        },
+        "displayOrder": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Display order for UI"
+        },
+        "configuration": {
+          "type": "string",
+          "title": "Provider configuration (non-sensitive fields only)"
+        },
+        "created": {
+          "type": "string",
+          "format": "int64",
+          "title": "Created timestamp"
+        },
+        "updated": {
+          "type": "string",
+          "format": "int64",
+          "title": "Updated timestamp"
+        },
+        "createdBy": {
+          "type": "string",
+          "title": "Created by user"
+        },
+        "updatedBy": {
+          "type": "string",
+          "title": "Updated by user"
+        }
+      },
+      "title": "Identity provider instance get response"
+    },
+    "apiIdpInstanceListResp": {
+      "type": "object",
+      "properties": {
+        "instances": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiIdpInstanceSummary"
+          },
+          "title": "List of identity provider instances"
+        },
+        "totalCount": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Total count of instances (for pagination)"
+        }
+      },
+      "title": "Identity provider instance list response"
+    },
+    "apiIdpInstanceSummary": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "title": "Identity provider key"
+        },
+        "displayName": {
+          "type": "string",
+          "title": "Display name"
+        },
+        "providerType": {
+          "$ref": "#/definitions/apiIdpProviderType",
+          "title": "Provider type"
+        },
+        "enabled": {
+          "type": "boolean",
+          "title": "Whether configuration is enabled"
+        },
+        "displayOrder": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Display order for UI"
+        },
+        "created": {
+          "type": "string",
+          "format": "int64",
+          "title": "Created timestamp"
+        },
+        "updated": {
+          "type": "string",
+          "format": "int64",
+          "title": "Updated timestamp"
+        }
+      },
+      "title": "Identity provider instance summary (for list responses)"
+    },
+    "apiIdpInstanceUpdateResp": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "title": "Success message"
+        }
+      },
+      "title": "Identity provider instance update response"
+    },
+    "apiIdpProviderMetadata": {
+      "type": "object",
+      "properties": {
+        "providerType": {
+          "$ref": "#/definitions/apiIdpProviderType"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "configFields": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiIdpConfigField"
+          }
+        },
+        "supportedScopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "defaultScopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "documentation": {
+          "type": "string"
+        }
+      },
+      "title": "Provider metadata"
+    },
+    "apiIdpProviderType": {
+      "type": "string",
+      "enum": [
+        "IdentityProviderUnspecified",
+        "Google",
+        "Microsoft",
+        "OIDC",
+        "SAML"
+      ],
+      "default": "IdentityProviderUnspecified",
+      "title": "Identity Provider types"
+    },
+    "apiIdpProvidersResp": {
+      "type": "object",
+      "properties": {
+        "providers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiIdpProviderMetadata"
+          },
+          "title": "Available provider types and their metadata"
+        }
+      },
+      "title": "Identity provider providers response"
     },
     "apiMyAzsListEntry": {
       "type": "object",

--- a/main.go
+++ b/main.go
@@ -360,6 +360,12 @@ func main() {
 		log.Panicf("failed to locate email verification table: %s", err)
 	}
 
+	// locate SSO config table
+	_, err = table.LocateIdentityProviderTable(client)
+	if err != nil {
+		log.Panicf("failed to locate Identity Provider table: %s", err)
+	}
+
 	// locate Org Unit table
 	ouTable, err := table.LocateOrgUnitTable(client)
 	if err != nil {

--- a/pkg/server/mytenant.go
+++ b/pkg/server/mytenant.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Nerzal/gocloak/v13"
 	"github.com/go-core-stack/auth-gateway/api"
@@ -24,6 +25,7 @@ import (
 type MyTenantServer struct {
 	api.UnimplementedMyTenantServer
 	client *keycloak.Client
+	// idpTable *table.IdentityProviderTable // REMOVED - using stubs instead
 }
 
 func (s *MyTenantServer) GetMyPasswordPolicy(ctx context.Context, req *api.MyPasswordPolicyGetReq) (*api.MyPasswordPolicyGetResp, error) {
@@ -151,9 +153,363 @@ func (s *MyTenantServer) UpdateMyPasswordPolicy(ctx context.Context, req *api.My
 	return &api.MyPasswordPolicyUpdateResp{}, nil
 }
 
+// Identity Provider Management Methods - STUB IMPLEMENTATIONS
+
+func (s *MyTenantServer) GetIdentityProviderTypes(ctx context.Context, req *api.IdpProvidersReq) (*api.IdpProvidersResp, error) {
+	// Return available provider types metadata
+	allProviders := []*api.IdpProviderMetadata{
+		{
+			ProviderType: api.IdpProviderType_Google,
+			DisplayName:  "Google OAuth2",
+			Description:  "Google OAuth2 identity provider for Gmail and Google Workspace accounts",
+			ConfigFields: []*api.IdpConfigField{
+				{
+					Name:        "client_id",
+					Type:        "string",
+					Required:    true,
+					Sensitive:   false,
+					Description: "OAuth2 client ID from Google Console",
+				},
+				{
+					Name:        "client_secret",
+					Type:        "string",
+					Required:    true,
+					Sensitive:   true,
+					Description: "OAuth2 client secret from Google Console",
+				},
+			},
+			SupportedScopes: []string{"openid", "email", "profile"},
+			DefaultScopes:   []string{"openid", "email", "profile"},
+			Documentation:   "https://developers.google.com/identity/protocols/oauth2",
+		},
+		{
+			ProviderType: api.IdpProviderType_Microsoft,
+			DisplayName:  "Microsoft OAuth2",
+			Description:  "Microsoft OAuth2 identity provider for Azure AD and Office 365 accounts",
+			ConfigFields: []*api.IdpConfigField{
+				{
+					Name:        "client_id",
+					Type:        "string",
+					Required:    true,
+					Sensitive:   false,
+					Description: "Application (client) ID from Azure portal",
+				},
+				{
+					Name:        "client_secret",
+					Type:        "string",
+					Required:    true,
+					Sensitive:   true,
+					Description: "Client secret from Azure portal",
+				},
+				{
+					Name:         "tenant_id",
+					Type:         "string",
+					Required:     false,
+					Sensitive:    false,
+					Description:  "Azure AD tenant ID (optional, defaults to common)",
+					DefaultValue: "common",
+				},
+			},
+			SupportedScopes: []string{"openid", "email", "profile", "User.Read"},
+			DefaultScopes:   []string{"openid", "email", "profile"},
+			Documentation:   "https://docs.microsoft.com/en-us/azure/active-directory/develop/",
+		},
+		{
+			ProviderType: api.IdpProviderType_OIDC,
+			DisplayName:  "OpenID Connect",
+			Description:  "Generic OpenID Connect identity provider",
+			ConfigFields: []*api.IdpConfigField{
+				{
+					Name:        "issuer_url",
+					Type:        "string",
+					Required:    true,
+					Sensitive:   false,
+					Description: "OpenID Connect issuer URL",
+				},
+				{
+					Name:        "client_id",
+					Type:        "string",
+					Required:    true,
+					Sensitive:   false,
+					Description: "OpenID Connect client ID",
+				},
+				{
+					Name:        "client_secret",
+					Type:        "string",
+					Required:    true,
+					Sensitive:   true,
+					Description: "OpenID Connect client secret",
+				},
+			},
+			SupportedScopes: []string{"openid", "email", "profile"},
+			DefaultScopes:   []string{"openid", "email", "profile"},
+			Documentation:   "https://openid.net/connect/",
+		},
+		{
+			ProviderType: api.IdpProviderType_SAML,
+			DisplayName:  "SAML 2.0",
+			Description:  "SAML 2.0 identity provider",
+			ConfigFields: []*api.IdpConfigField{
+				{
+					Name:        "sso_url",
+					Type:        "string",
+					Required:    true,
+					Sensitive:   false,
+					Description: "SAML SSO URL",
+				},
+				{
+					Name:        "entity_id",
+					Type:        "string",
+					Required:    true,
+					Sensitive:   false,
+					Description: "SAML entity ID",
+				},
+				{
+					Name:        "certificate",
+					Type:        "string",
+					Required:    true,
+					Sensitive:   false,
+					Description: "X.509 certificate for signature verification",
+				},
+			},
+			SupportedScopes: []string{},
+			DefaultScopes:   []string{},
+			Documentation:   "https://en.wikipedia.org/wiki/SAML_2.0",
+		},
+	}
+
+	// Filter providers if a specific type is requested
+	var providers []*api.IdpProviderMetadata
+	if req.GetProviderType() != api.IdpProviderType_IdentityProviderUnspecified {
+		// Find the specific provider type
+		for _, provider := range allProviders {
+			if provider.ProviderType == req.GetProviderType() {
+				providers = append(providers, provider)
+				break
+			}
+		}
+	} else {
+		// Return all providers if no filter specified
+		providers = allProviders
+	}
+
+	return &api.IdpProvidersResp{
+		Providers: providers,
+	}, nil
+}
+
+func (s *MyTenantServer) CreateIdentityProviderInstance(ctx context.Context, req *api.IdpInstanceCreateReq) (*api.IdpInstanceCreateResp, error) {
+	authInfo, _ := auth.GetAuthInfoFromContext(ctx)
+	if authInfo == nil {
+		return nil, status.Error(codes.Unauthenticated, "authentication required")
+	}
+
+	// Basic validation
+	if strings.TrimSpace(req.Key) == "" {
+		return nil, status.Error(codes.InvalidArgument, "identity provider key is required")
+	}
+
+	if req.ProviderType == api.IdpProviderType_IdentityProviderUnspecified {
+		return nil, status.Error(codes.InvalidArgument, "provider type is required")
+	}
+
+	// STUB: Just return success without actual creation
+	return &api.IdpInstanceCreateResp{
+		Key:     req.Key,
+		Message: fmt.Sprintf("Identity provider '%s' would be created successfully (STUB)", req.Key),
+	}, nil
+}
+
+func (s *MyTenantServer) ListIdentityProviderInstances(ctx context.Context, req *api.IdpInstanceListReq) (*api.IdpInstanceListResp, error) {
+	authInfo, _ := auth.GetAuthInfoFromContext(ctx)
+	if authInfo == nil {
+		return nil, status.Error(codes.Unauthenticated, "authentication required")
+	}
+
+	// STUB: Return mock data
+	mockInstances := []*api.IdpInstanceSummary{
+		{
+			Key:          "google-sso",
+			DisplayName:  "Google SSO",
+			ProviderType: api.IdpProviderType_Google,
+			Enabled:      true,
+			DisplayOrder: 1,
+			Created:      time.Now().Unix() - 86400, // 1 day ago
+			Updated:      time.Now().Unix(),
+		},
+		{
+			Key:          "microsoft-sso",
+			DisplayName:  "Microsoft SSO",
+			ProviderType: api.IdpProviderType_Microsoft,
+			Enabled:      false,
+			DisplayOrder: 2,
+			Created:      time.Now().Unix() - 7200, // 2 hours ago
+			Updated:      time.Now().Unix() - 3600, // 1 hour ago
+		},
+	}
+
+	// Apply filters if provided
+	var filteredInstances []*api.IdpInstanceSummary
+	for _, instance := range mockInstances {
+		// Filter by provider type
+		if req.GetProviderType() != api.IdpProviderType_IdentityProviderUnspecified {
+			if instance.ProviderType != req.GetProviderType() {
+				continue
+			}
+		}
+
+		// Filter by enabled status
+		if req.Enabled != nil {
+			if instance.Enabled != req.GetEnabled() {
+				continue
+			}
+		}
+
+		filteredInstances = append(filteredInstances, instance)
+	}
+
+	// Apply pagination
+	totalCount := len(filteredInstances)
+	offset := int(req.GetOffset())
+	limit := int(req.GetLimit())
+
+	if limit <= 0 {
+		limit = 10 // Default limit
+	}
+
+	start := offset
+	if start > totalCount {
+		start = totalCount
+	}
+
+	end := start + limit
+	if end > totalCount {
+		end = totalCount
+	}
+
+	pagedInstances := filteredInstances[start:end]
+
+	return &api.IdpInstanceListResp{
+		Instances:  pagedInstances,
+		TotalCount: int32(totalCount),
+	}, nil
+}
+
+func (s *MyTenantServer) GetIdentityProviderInstance(ctx context.Context, req *api.IdpInstanceGetReq) (*api.IdpInstanceGetResp, error) {
+	authInfo, _ := auth.GetAuthInfoFromContext(ctx)
+	if authInfo == nil {
+		return nil, status.Error(codes.Unauthenticated, "authentication required")
+	}
+
+	if strings.TrimSpace(req.Key) == "" {
+		return nil, status.Error(codes.InvalidArgument, "identity provider key is required")
+	}
+
+	// STUB: Return mock data based on key
+	switch req.Key {
+	case "google-sso":
+		return &api.IdpInstanceGetResp{
+			Key:           "google-sso",
+			DisplayName:   "Google SSO",
+			ProviderType:  api.IdpProviderType_Google,
+			Enabled:       true,
+			DisplayOrder:  1,
+			Configuration: `{"client_id":"stub-google-client-id","redirect_uri":"https://example.com/auth/callback"}`,
+			Created:       time.Now().Unix() - 86400,
+			Updated:       time.Now().Unix(),
+			CreatedBy:     "admin",
+			UpdatedBy:     "admin",
+		}, nil
+	case "microsoft-sso":
+		return &api.IdpInstanceGetResp{
+			Key:           "microsoft-sso",
+			DisplayName:   "Microsoft SSO",
+			ProviderType:  api.IdpProviderType_Microsoft,
+			Enabled:       false,
+			DisplayOrder:  2,
+			Configuration: `{"client_id":"stub-microsoft-client-id","tenant_id":"common"}`,
+			Created:       time.Now().Unix() - 7200,
+			Updated:       time.Now().Unix() - 3600,
+			CreatedBy:     "admin",
+			UpdatedBy:     "admin",
+		}, nil
+	default:
+		return nil, status.Errorf(codes.NotFound, "identity provider '%s' not found (STUB)", req.Key)
+	}
+}
+
+func (s *MyTenantServer) UpdateIdentityProviderInstance(ctx context.Context, req *api.IdpInstanceUpdateReq) (*api.IdpInstanceUpdateResp, error) {
+	authInfo, _ := auth.GetAuthInfoFromContext(ctx)
+	if authInfo == nil {
+		return nil, status.Error(codes.Unauthenticated, "authentication required")
+	}
+
+	if strings.TrimSpace(req.Key) == "" {
+		return nil, status.Error(codes.InvalidArgument, "identity provider key is required")
+	}
+
+	// STUB: Simulate checking if provider exists
+	validKeys := []string{"google-sso", "microsoft-sso"}
+	found := false
+	for _, validKey := range validKeys {
+		if req.Key == validKey {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil, status.Errorf(codes.NotFound, "identity provider '%s' not found (STUB)", req.Key)
+	}
+
+	// STUB: Just return success without actual update
+	return &api.IdpInstanceUpdateResp{
+		Message: fmt.Sprintf("Identity provider '%s' would be updated successfully (STUB)", req.Key),
+	}, nil
+}
+
+func (s *MyTenantServer) DeleteIdentityProviderInstance(ctx context.Context, req *api.IdpInstanceDeleteReq) (*api.IdpInstanceDeleteResp, error) {
+	authInfo, _ := auth.GetAuthInfoFromContext(ctx)
+	if authInfo == nil {
+		return nil, status.Error(codes.Unauthenticated, "authentication required")
+	}
+
+	if strings.TrimSpace(req.Key) == "" {
+		return nil, status.Error(codes.InvalidArgument, "identity provider key is required")
+	}
+
+	// STUB: Simulate checking if provider exists
+	validKeys := []string{"google-sso", "microsoft-sso"}
+	found := false
+	for _, validKey := range validKeys {
+		if req.Key == validKey {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil, status.Errorf(codes.NotFound, "identity provider '%s' not found (STUB)", req.Key)
+	}
+
+	// STUB: Just return success without actual deletion
+	return &api.IdpInstanceDeleteResp{
+		Message: fmt.Sprintf("Identity provider '%s' would be deleted successfully (STUB)", req.Key),
+	}, nil
+}
+
+// Helper methods for Identity Provider Management - REMOVED (STUBS DON'T NEED THESE)
+
 func NewMyTenantServer(ctx *model.GrpcServerContext, client *keycloak.Client, ep string) *MyTenantServer {
+	// REMOVED: Database dependency - using stubs instead
+	// idpTbl, err := table.GetIdentityProviderTable()
+	// if err != nil {
+	//	log.Panicf("failed to get identity provider table: %s", err)
+	// }
+
 	srv := &MyTenantServer{
 		client: client,
+		// idpTable: idpTbl, // REMOVED - using stubs instead
 	}
 	api.RegisterMyTenantServer(ctx.Server, srv)
 	err := api.RegisterMyTenantHandler(context.Background(), ctx.Mux, ctx.Conn)

--- a/pkg/server/mytenant.go
+++ b/pkg/server/mytenant.go
@@ -155,150 +155,23 @@ func (s *MyTenantServer) UpdateMyPasswordPolicy(ctx context.Context, req *api.My
 
 // Identity Provider Management Methods - STUB IMPLEMENTATIONS
 
-func (s *MyTenantServer) GetIdentityProviderTypes(ctx context.Context, req *api.IdpProvidersReq) (*api.IdpProvidersResp, error) {
+func (s *MyTenantServer) GetMyIdentityProviderTypes(ctx context.Context, req *api.IdentityProviderTypesGetReq) (*api.IdentityProviderTypesGetResp, error) {
 	// Return available provider types metadata
-	allProviders := []*api.IdpProviderMetadata{
+	allProviders := []*api.IdentityProviderTypesListEntry{
 		{
-			ProviderType: api.IdpProviderType_Google,
-			DisplayName:  "Google OAuth2",
-			Description:  "Google OAuth2 identity provider for Gmail and Google Workspace accounts",
-			ConfigFields: []*api.IdpConfigField{
-				{
-					Name:        "client_id",
-					Type:        "string",
-					Required:    true,
-					Sensitive:   false,
-					Description: "OAuth2 client ID from Google Console",
-				},
-				{
-					Name:        "client_secret",
-					Type:        "string",
-					Required:    true,
-					Sensitive:   true,
-					Description: "OAuth2 client secret from Google Console",
-				},
-			},
-			SupportedScopes: []string{"openid", "email", "profile"},
-			DefaultScopes:   []string{"openid", "email", "profile"},
-			Documentation:   "https://developers.google.com/identity/protocols/oauth2",
+			Type: "google",
 		},
 		{
-			ProviderType: api.IdpProviderType_Microsoft,
-			DisplayName:  "Microsoft OAuth2",
-			Description:  "Microsoft OAuth2 identity provider for Azure AD and Office 365 accounts",
-			ConfigFields: []*api.IdpConfigField{
-				{
-					Name:        "client_id",
-					Type:        "string",
-					Required:    true,
-					Sensitive:   false,
-					Description: "Application (client) ID from Azure portal",
-				},
-				{
-					Name:        "client_secret",
-					Type:        "string",
-					Required:    true,
-					Sensitive:   true,
-					Description: "Client secret from Azure portal",
-				},
-				{
-					Name:         "tenant_id",
-					Type:         "string",
-					Required:     false,
-					Sensitive:    false,
-					Description:  "Azure AD tenant ID (optional, defaults to common)",
-					DefaultValue: "common",
-				},
-			},
-			SupportedScopes: []string{"openid", "email", "profile", "User.Read"},
-			DefaultScopes:   []string{"openid", "email", "profile"},
-			Documentation:   "https://docs.microsoft.com/en-us/azure/active-directory/develop/",
-		},
-		{
-			ProviderType: api.IdpProviderType_OIDC,
-			DisplayName:  "OpenID Connect",
-			Description:  "Generic OpenID Connect identity provider",
-			ConfigFields: []*api.IdpConfigField{
-				{
-					Name:        "issuer_url",
-					Type:        "string",
-					Required:    true,
-					Sensitive:   false,
-					Description: "OpenID Connect issuer URL",
-				},
-				{
-					Name:        "client_id",
-					Type:        "string",
-					Required:    true,
-					Sensitive:   false,
-					Description: "OpenID Connect client ID",
-				},
-				{
-					Name:        "client_secret",
-					Type:        "string",
-					Required:    true,
-					Sensitive:   true,
-					Description: "OpenID Connect client secret",
-				},
-			},
-			SupportedScopes: []string{"openid", "email", "profile"},
-			DefaultScopes:   []string{"openid", "email", "profile"},
-			Documentation:   "https://openid.net/connect/",
-		},
-		{
-			ProviderType: api.IdpProviderType_SAML,
-			DisplayName:  "SAML 2.0",
-			Description:  "SAML 2.0 identity provider",
-			ConfigFields: []*api.IdpConfigField{
-				{
-					Name:        "sso_url",
-					Type:        "string",
-					Required:    true,
-					Sensitive:   false,
-					Description: "SAML SSO URL",
-				},
-				{
-					Name:        "entity_id",
-					Type:        "string",
-					Required:    true,
-					Sensitive:   false,
-					Description: "SAML entity ID",
-				},
-				{
-					Name:        "certificate",
-					Type:        "string",
-					Required:    true,
-					Sensitive:   false,
-					Description: "X.509 certificate for signature verification",
-				},
-			},
-			SupportedScopes: []string{},
-			DefaultScopes:   []string{},
-			Documentation:   "https://en.wikipedia.org/wiki/SAML_2.0",
+			Type: "microsoft",
 		},
 	}
 
-	// Filter providers if a specific type is requested
-	var providers []*api.IdpProviderMetadata
-	if req.GetProviderType() != api.IdpProviderType_IdentityProviderUnspecified {
-		// Find the specific provider type
-		for _, provider := range allProviders {
-			if provider.ProviderType == req.GetProviderType() {
-				providers = append(providers, provider)
-				break
-			}
-		}
-	} else {
-		// Return all providers if no filter specified
-		providers = allProviders
-	}
-
-	return &api.IdpProvidersResp{
-		Providers: providers,
+	return &api.IdentityProviderTypesGetResp{
+		Providers: allProviders,
 	}, nil
 }
 
-func (s *MyTenantServer) CreateIdentityProviderInstance(ctx context.Context, req *api.IdpInstanceCreateReq) (*api.IdpInstanceCreateResp, error) {
+func (s *MyTenantServer) CreateMyIdentityProvider(ctx context.Context, req *api.MyIdentityProviderCreateReq) (*api.MyIdentityProviderCreateResp, error) {
 	authInfo, _ := auth.GetAuthInfoFromContext(ctx)
 	if authInfo == nil {
 		return nil, status.Error(codes.Unauthenticated, "authentication required")
@@ -309,58 +182,51 @@ func (s *MyTenantServer) CreateIdentityProviderInstance(ctx context.Context, req
 		return nil, status.Error(codes.InvalidArgument, "identity provider key is required")
 	}
 
-	if req.ProviderType == api.IdpProviderType_IdentityProviderUnspecified {
+	if req.Type == api.IdentityProviderDefs_IdentityProviderUnspecified {
 		return nil, status.Error(codes.InvalidArgument, "provider type is required")
 	}
 
 	// STUB: Just return success without actual creation
-	return &api.IdpInstanceCreateResp{
-		Key:     req.Key,
-		Message: fmt.Sprintf("Identity provider '%s' would be created successfully (STUB)", req.Key),
-	}, nil
+	return &api.MyIdentityProviderCreateResp{}, nil
 }
 
-func (s *MyTenantServer) ListIdentityProviderInstances(ctx context.Context, req *api.IdpInstanceListReq) (*api.IdpInstanceListResp, error) {
+func (s *MyTenantServer) ListMyIdentityProviders(ctx context.Context, req *api.MyIdentityProvidersListReq) (*api.MyIdentityProvidersListResp, error) {
 	authInfo, _ := auth.GetAuthInfoFromContext(ctx)
 	if authInfo == nil {
 		return nil, status.Error(codes.Unauthenticated, "authentication required")
 	}
 
 	// STUB: Return mock data
-	mockInstances := []*api.IdpInstanceSummary{
+	mockInstances := []*api.MyIdentityProvidersListEntry{
 		{
-			Key:          "google-sso",
-			DisplayName:  "Google SSO",
-			ProviderType: api.IdpProviderType_Google,
-			Enabled:      true,
-			DisplayOrder: 1,
-			Created:      time.Now().Unix() - 86400, // 1 day ago
-			Updated:      time.Now().Unix(),
+			Key:      "google-sso",
+			DispName: "Google SSO",
+			Type:     api.IdentityProviderDefs_Google,
+			Enabled:  true,
+			Created:  time.Now().Unix() - 86400, // 1 day ago
 		},
 		{
-			Key:          "microsoft-sso",
-			DisplayName:  "Microsoft SSO",
-			ProviderType: api.IdpProviderType_Microsoft,
-			Enabled:      false,
-			DisplayOrder: 2,
-			Created:      time.Now().Unix() - 7200, // 2 hours ago
-			Updated:      time.Now().Unix() - 3600, // 1 hour ago
+			Key:      "microsoft-sso",
+			DispName: "Microsoft SSO",
+			Type:     api.IdentityProviderDefs_Microsoft,
+			Enabled:  false,
+			Created:  time.Now().Unix() - 7200, // 2 hours ago
 		},
 	}
 
 	// Apply filters if provided
-	var filteredInstances []*api.IdpInstanceSummary
+	var filteredInstances []*api.MyIdentityProvidersListEntry
 	for _, instance := range mockInstances {
 		// Filter by provider type
-		if req.GetProviderType() != api.IdpProviderType_IdentityProviderUnspecified {
-			if instance.ProviderType != req.GetProviderType() {
+		if req.Type != nil {
+			if instance.Type != *req.Type {
 				continue
 			}
 		}
 
 		// Filter by enabled status
 		if req.Enabled != nil {
-			if instance.Enabled != req.GetEnabled() {
+			if instance.Enabled != *req.Enabled {
 				continue
 			}
 		}
@@ -389,13 +255,13 @@ func (s *MyTenantServer) ListIdentityProviderInstances(ctx context.Context, req 
 
 	pagedInstances := filteredInstances[start:end]
 
-	return &api.IdpInstanceListResp{
-		Instances:  pagedInstances,
-		TotalCount: int32(totalCount),
+	return &api.MyIdentityProvidersListResp{
+		Items: pagedInstances,
+		Count: int32(totalCount),
 	}, nil
 }
 
-func (s *MyTenantServer) GetIdentityProviderInstance(ctx context.Context, req *api.IdpInstanceGetReq) (*api.IdpInstanceGetResp, error) {
+func (s *MyTenantServer) GetMyIdentityProvider(ctx context.Context, req *api.MyIdentityProviderGetReq) (*api.MyIdentityProviderGetResp, error) {
 	authInfo, _ := auth.GetAuthInfoFromContext(ctx)
 	if authInfo == nil {
 		return nil, status.Error(codes.Unauthenticated, "authentication required")
@@ -408,37 +274,39 @@ func (s *MyTenantServer) GetIdentityProviderInstance(ctx context.Context, req *a
 	// STUB: Return mock data based on key
 	switch req.Key {
 	case "google-sso":
-		return &api.IdpInstanceGetResp{
-			Key:           "google-sso",
-			DisplayName:   "Google SSO",
-			ProviderType:  api.IdpProviderType_Google,
-			Enabled:       true,
-			DisplayOrder:  1,
-			Configuration: `{"client_id":"stub-google-client-id","redirect_uri":"https://example.com/auth/callback"}`,
-			Created:       time.Now().Unix() - 86400,
-			Updated:       time.Now().Unix(),
-			CreatedBy:     "admin",
-			UpdatedBy:     "admin",
+		return &api.MyIdentityProviderGetResp{
+			Key:       "google-sso",
+			DispName:  "Google SSO",
+			Type:      api.IdentityProviderDefs_Google,
+			Enabled:   true,
+			Created:   time.Now().Unix() - 86400,
+			CreatedBy: "admin",
+			Google: &api.GoogleIDPConfig{
+				ClientId:     "stub-google-client-id",
+				ClientSecret: "stub-google-client-secret",
+				HostedDomain: "example.com",
+			},
 		}, nil
 	case "microsoft-sso":
-		return &api.IdpInstanceGetResp{
-			Key:           "microsoft-sso",
-			DisplayName:   "Microsoft SSO",
-			ProviderType:  api.IdpProviderType_Microsoft,
-			Enabled:       false,
-			DisplayOrder:  2,
-			Configuration: `{"client_id":"stub-microsoft-client-id","tenant_id":"common"}`,
-			Created:       time.Now().Unix() - 7200,
-			Updated:       time.Now().Unix() - 3600,
-			CreatedBy:     "admin",
-			UpdatedBy:     "admin",
+		return &api.MyIdentityProviderGetResp{
+			Key:       "microsoft-sso",
+			DispName:  "Microsoft SSO",
+			Type:      api.IdentityProviderDefs_Microsoft,
+			Enabled:   false,
+			Created:   time.Now().Unix() - 7200,
+			CreatedBy: "admin",
+			Microsoft: &api.MicrosoftIDPConfig{
+				ClientId:     "stub-microsoft-client-id",
+				ClientSecret: "stub-microsoft-client-secret",
+				TenantId:     "common",
+			},
 		}, nil
 	default:
 		return nil, status.Errorf(codes.NotFound, "identity provider '%s' not found (STUB)", req.Key)
 	}
 }
 
-func (s *MyTenantServer) UpdateIdentityProviderInstance(ctx context.Context, req *api.IdpInstanceUpdateReq) (*api.IdpInstanceUpdateResp, error) {
+func (s *MyTenantServer) UpdateMyIdentityProvider(ctx context.Context, req *api.MyIdentityProviderUpdateReq) (*api.MyIdentityProviderUpdateResp, error) {
 	authInfo, _ := auth.GetAuthInfoFromContext(ctx)
 	if authInfo == nil {
 		return nil, status.Error(codes.Unauthenticated, "authentication required")
@@ -463,12 +331,10 @@ func (s *MyTenantServer) UpdateIdentityProviderInstance(ctx context.Context, req
 	}
 
 	// STUB: Just return success without actual update
-	return &api.IdpInstanceUpdateResp{
-		Message: fmt.Sprintf("Identity provider '%s' would be updated successfully (STUB)", req.Key),
-	}, nil
+	return &api.MyIdentityProviderUpdateResp{}, nil
 }
 
-func (s *MyTenantServer) DeleteIdentityProviderInstance(ctx context.Context, req *api.IdpInstanceDeleteReq) (*api.IdpInstanceDeleteResp, error) {
+func (s *MyTenantServer) DeleteMyIdentityProvider(ctx context.Context, req *api.MyIdentityProviderDeleteReq) (*api.MyIdentityProviderDeleteResp, error) {
 	authInfo, _ := auth.GetAuthInfoFromContext(ctx)
 	if authInfo == nil {
 		return nil, status.Error(codes.Unauthenticated, "authentication required")
@@ -493,9 +359,7 @@ func (s *MyTenantServer) DeleteIdentityProviderInstance(ctx context.Context, req
 	}
 
 	// STUB: Just return success without actual deletion
-	return &api.IdpInstanceDeleteResp{
-		Message: fmt.Sprintf("Identity provider '%s' would be deleted successfully (STUB)", req.Key),
-	}, nil
+	return &api.MyIdentityProviderDeleteResp{}, nil
 }
 
 // Helper methods for Identity Provider Management - REMOVED (STUBS DON'T NEED THESE)

--- a/pkg/table/const.go
+++ b/pkg/table/const.go
@@ -26,4 +26,7 @@ const (
 
 	// Org Unit User collection name
 	OrgUnitUserCollectionName = "org-unit-users"
+
+	// Identity Provider collection name
+	IdentityProviderCollectionName = "identity-providers"
 )

--- a/pkg/table/identity-provider.go
+++ b/pkg/table/identity-provider.go
@@ -1,0 +1,620 @@
+// Copyright © 2025 Prabhjot Singh Sethi, All Rights reserved
+// Author: Prabhjot Singh Sethi <prabhjot.sethi@gmail.com>
+
+package table
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+
+	"github.com/go-core-stack/core/db"
+	"github.com/go-core-stack/core/errors"
+	"github.com/go-core-stack/core/table"
+	"github.com/google/uuid"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+var identityProviderTable *IdentityProviderTable
+
+// ProviderType represents the type of identity provider
+type ProviderType string
+
+const (
+	ProviderTypeUnspecified ProviderType = ""
+	ProviderTypeGoogle      ProviderType = "google"
+	ProviderTypeMicrosoft   ProviderType = "microsoft"
+	ProviderTypeOIDC        ProviderType = "oidc"
+	ProviderTypeSAML        ProviderType = "saml"
+)
+
+// IdentityProviderKey represents the composite key for identity providers
+type IdentityProviderKey struct {
+	Tenant string `bson:"tenant"`
+	Alias  string `bson:"alias"`
+}
+
+// ProviderSecrets contains encrypted sensitive configuration data
+type ProviderSecrets struct {
+	ClientSecret      string            `bson:"clientSecret,omitempty"`
+	PrivateKey        string            `bson:"privateKey,omitempty"`
+	Certificate       string            `bson:"certificate,omitempty"`
+	AdditionalSecrets map[string]string `bson:"additionalSecrets,omitempty"`
+}
+
+// MarshalBSON implements custom BSON marshaling for encryption
+func (s *ProviderSecrets) MarshalBSON() ([]byte, error) {
+	type Alias ProviderSecrets
+	// Create a value copy of the receiver to avoid mutating the original
+	secrets := Alias(*s)
+
+	// Encrypt sensitive data before storing
+	if s.ClientSecret != "" {
+		encrypted, err := encryptor.EncryptString(s.ClientSecret)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encrypt client secret: %w", err)
+		}
+		secrets.ClientSecret = encrypted
+	}
+
+	if s.PrivateKey != "" {
+		encrypted, err := encryptor.EncryptString(s.PrivateKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encrypt private key: %w", err)
+		}
+		secrets.PrivateKey = encrypted
+	}
+
+	if s.Certificate != "" {
+		encrypted, err := encryptor.EncryptString(s.Certificate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encrypt certificate: %w", err)
+		}
+		secrets.Certificate = encrypted
+	}
+
+	// Encrypt additional secrets
+	if s.AdditionalSecrets != nil {
+		encryptedSecrets := make(map[string]string, len(s.AdditionalSecrets))
+		for key, value := range s.AdditionalSecrets {
+			encrypted, err := encryptor.EncryptString(value)
+			if err != nil {
+				return nil, fmt.Errorf("failed to encrypt additional secret '%s': %w", key, err)
+			}
+			encryptedSecrets[key] = encrypted
+		}
+		secrets.AdditionalSecrets = encryptedSecrets
+	}
+
+	return bson.Marshal(secrets)
+}
+
+// UnmarshalBSON implements custom BSON unmarshaling for decryption
+func (s *ProviderSecrets) UnmarshalBSON(data []byte) error {
+	type Alias ProviderSecrets
+	secrets := &Alias{}
+
+	if err := bson.Unmarshal(data, secrets); err != nil {
+		return err
+	}
+
+	// Decrypt sensitive data after loading
+	if secrets.ClientSecret != "" {
+		decrypted, err := encryptor.DecryptString(secrets.ClientSecret)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt client secret: %w", err)
+		}
+		s.ClientSecret = decrypted
+	}
+
+	if secrets.PrivateKey != "" {
+		decrypted, err := encryptor.DecryptString(secrets.PrivateKey)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt private key: %w", err)
+		}
+		s.PrivateKey = decrypted
+	}
+
+	if secrets.Certificate != "" {
+		decrypted, err := encryptor.DecryptString(secrets.Certificate)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt certificate: %w", err)
+		}
+		s.Certificate = decrypted
+	}
+
+	// Decrypt additional secrets
+	if secrets.AdditionalSecrets != nil {
+		decryptedSecrets := make(map[string]string, len(secrets.AdditionalSecrets))
+		for key, value := range secrets.AdditionalSecrets {
+			decrypted, err := encryptor.DecryptString(value)
+			if err != nil {
+				return fmt.Errorf("failed to decrypt additional secret '%s': %w", key, err)
+			}
+			decryptedSecrets[key] = decrypted
+		}
+		s.AdditionalSecrets = decryptedSecrets
+	}
+
+	return nil
+}
+
+// IdentityProviderEntry represents a complete identity provider configuration
+type IdentityProviderEntry struct {
+	Key           *IdentityProviderKey   `bson:"key,omitempty"`
+	ProviderType  ProviderType           `bson:"providerType,omitempty"`
+	DisplayName   string                 `bson:"displayName,omitempty"`
+	DisplayOrder  int                    `bson:"displayOrder,omitempty"`
+	Enabled       bool                   `bson:"enabled,omitempty"`
+	Configuration map[string]interface{} `bson:"configuration,omitempty"`
+	Secrets       *ProviderSecrets       `bson:"secrets,omitempty"`
+	Created       int64                  `bson:"created,omitempty"`
+	Updated       int64                  `bson:"updated,omitempty"`
+	CreatedBy     string                 `bson:"createdBy,omitempty"`
+	UpdatedBy     string                 `bson:"updatedBy,omitempty"`
+}
+
+// IdentityProviderTable implements the table interface for identity providers
+type IdentityProviderTable struct {
+	table.Table[IdentityProviderKey, IdentityProviderEntry]
+	col db.StoreCollection
+}
+
+// GoogleOAuth2Config represents Google OAuth2 provider configuration
+type GoogleOAuth2Config struct {
+	ClientID             string `json:"client_id" validate:"required"`
+	ClientSecret         string `json:"client_secret" validate:"required"`
+	RedirectURI          string `json:"redirect_uri,omitempty"`
+	HostedDomain         string `json:"hosted_domain,omitempty"`
+	Prompt               string `json:"prompt,omitempty"`
+	UseUserIPParam       bool   `json:"use_userip_param"`
+	RequestRefreshToken  bool   `json:"request_refresh_token"`
+	AdditionalScopes     string `json:"additional_scopes,omitempty"`
+	LoginHint            string `json:"login_hint,omitempty"`
+	IncludeGrantedScopes bool   `json:"include_granted_scopes"`
+}
+
+// MicrosoftOAuth2Config represents Microsoft OAuth2 provider configuration
+type MicrosoftOAuth2Config struct {
+	ClientID         string `json:"client_id" validate:"required"`
+	ClientSecret     string `json:"client_secret" validate:"required"`
+	RedirectURI      string `json:"redirect_uri,omitempty"`
+	TenantID         string `json:"tenant_id,omitempty"`
+	Prompt           string `json:"prompt,omitempty"`
+	AdditionalScopes string `json:"additional_scopes,omitempty"`
+	DomainHint       string `json:"domain_hint,omitempty"`
+	LoginHint        string `json:"login_hint,omitempty"`
+}
+
+// OIDCConfig represents OpenID Connect provider configuration
+type OIDCConfig struct {
+	ClientID                          string `json:"client_id" validate:"required"`
+	ClientSecret                      string `json:"client_secret" validate:"required"`
+	DiscoveryEndpoint                 string `json:"discovery_endpoint" validate:"required"`
+	RedirectURI                       string `json:"redirect_uri,omitempty"`
+	UseDiscoveryEndpoint              bool   `json:"use_discovery_endpoint"`
+	ClientAuthentication              string `json:"client_authentication,omitempty"`
+	ClientAssertionSignatureAlgorithm string `json:"client_assertion_signature_algorithm,omitempty"`
+	AdditionalScopes                  string `json:"additional_scopes,omitempty"`
+	ValidateSignatures                bool   `json:"validate_signatures"`
+	UseJWKSURL                        bool   `json:"use_jwks_url"`
+	JWKSURL                           string `json:"jwks_url,omitempty"`
+}
+
+// SAMLConfig represents SAML provider configuration
+type SAMLConfig struct {
+	ServiceProviderEntityID  string `json:"service_provider_entity_id" validate:"required"`
+	SAMLEntityDescriptor     string `json:"saml_entity_descriptor" validate:"required"`
+	SSOServiceURL            string `json:"sso_service_url" validate:"required"`
+	RedirectURI              string `json:"redirect_uri,omitempty"`
+	IdentityProviderEntityID string `json:"identity_provider_entity_id,omitempty"`
+	SingleLogoutServiceURL   string `json:"single_logout_service_url,omitempty"`
+	NameIDPolicyFormat       string `json:"nameid_policy_format,omitempty"`
+	WantAuthnRequestsSigned  bool   `json:"want_authn_requests_signed"`
+	ValidateSignatures       bool   `json:"validate_signatures"`
+	SigningCertificate       string `json:"signing_certificate,omitempty"`
+	EncryptionCertificate    string `json:"encryption_certificate,omitempty"`
+	ForceAuthentication      bool   `json:"force_authentication"`
+	PostBindingResponse      bool   `json:"post_binding_response"`
+	PostBindingLogout        bool   `json:"post_binding_logout"`
+	WantAssertionsSigned     bool   `json:"want_assertions_signed"`
+	WantAssertionsEncrypted  bool   `json:"want_assertions_encrypted"`
+	SignatureAlgorithm       string `json:"signature_algorithm,omitempty"`
+	SAMLSignatureKeyName     string `json:"saml_signature_key_name,omitempty"`
+	CanonalizationMethod     string `json:"canonicalization_method,omitempty"`
+}
+
+// ProviderConfigField represents metadata about configuration fields
+type ProviderConfigField struct {
+	Name         string      `json:"name"`
+	Type         string      `json:"type"`
+	Required     bool        `json:"required"`
+	Sensitive    bool        `json:"sensitive"`
+	Description  string      `json:"description"`
+	DefaultValue interface{} `json:"default_value,omitempty"`
+	Validation   string      `json:"validation,omitempty"`
+}
+
+// ProviderMetadata contains metadata about each provider type
+type ProviderMetadata struct {
+	ProviderType    ProviderType          `json:"provider_type"`
+	DisplayName     string                `json:"display_name"`
+	Description     string                `json:"description"`
+	ConfigFields    []ProviderConfigField `json:"config_fields"`
+	SupportedScopes []string              `json:"supported_scopes,omitempty"`
+	DefaultScopes   []string              `json:"default_scopes,omitempty"`
+	Documentation   string                `json:"documentation,omitempty"`
+}
+
+// GetIdentityProviderTable returns the identity provider table instance
+func GetIdentityProviderTable() (*IdentityProviderTable, error) {
+	if identityProviderTable != nil {
+		return identityProviderTable, nil
+	}
+
+	return nil, errors.Wrapf(errors.NotFound, "identity provider table not found")
+}
+
+// LocateIdentityProviderTable locates and initializes the identity provider table
+func LocateIdentityProviderTable(client db.StoreClient) (*IdentityProviderTable, error) {
+	if identityProviderTable != nil {
+		return identityProviderTable, nil
+	}
+
+	col := client.GetCollection(AuthDatabaseName, IdentityProviderCollectionName)
+	tbl := &IdentityProviderTable{
+		col: col,
+	}
+
+	// Initialize the embedded Table with the same collection
+	err := tbl.Initialize(col)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("DEBUG: LocateIdentityProviderTable - initialized table with collection")
+
+	identityProviderTable = tbl
+
+	return identityProviderTable, nil
+}
+
+// GetProviderMetadata returns metadata for all supported provider types
+func GetProviderMetadata() map[ProviderType]ProviderMetadata {
+	return map[ProviderType]ProviderMetadata{
+		ProviderTypeGoogle: {
+			ProviderType: ProviderTypeGoogle,
+			DisplayName:  "Google",
+			Description:  "Google OAuth2 authentication provider",
+			ConfigFields: []ProviderConfigField{
+				{Name: "client_id", Type: "string", Required: true, Description: "Google OAuth2 Client ID"},
+				{Name: "client_secret", Type: "string", Required: true, Sensitive: true, Description: "Google OAuth2 Client Secret"},
+				{Name: "redirect_uri", Type: "url", Required: false, Description: "OAuth2 redirect URI"},
+				{Name: "hosted_domain", Type: "string", Required: false, Description: "Google Workspace domain restriction"},
+				{Name: "prompt", Type: "string", Required: false, Description: "OAuth2 prompt parameter"},
+				{Name: "use_userip_param", Type: "boolean", Required: false, DefaultValue: false, Description: "Include user IP in requests"},
+				{Name: "request_refresh_token", Type: "boolean", Required: false, DefaultValue: false, Description: "Request refresh token"},
+			},
+			SupportedScopes: []string{"openid", "email", "profile"},
+			DefaultScopes:   []string{"openid", "email", "profile"},
+			Documentation:   "https://developers.google.com/identity/protocols/oauth2",
+		},
+		ProviderTypeMicrosoft: {
+			ProviderType: ProviderTypeMicrosoft,
+			DisplayName:  "Microsoft",
+			Description:  "Microsoft OAuth2 authentication provider",
+			ConfigFields: []ProviderConfigField{
+				{Name: "client_id", Type: "string", Required: true, Description: "Microsoft Application (client) ID"},
+				{Name: "client_secret", Type: "string", Required: true, Sensitive: true, Description: "Microsoft Client Secret"},
+				{Name: "redirect_uri", Type: "url", Required: false, Description: "OAuth2 redirect URI"},
+				{Name: "tenant_id", Type: "string", Required: false, DefaultValue: "common", Description: "Microsoft tenant ID"},
+				{Name: "prompt", Type: "string", Required: false, Description: "OAuth2 prompt parameter"},
+				{Name: "domain_hint", Type: "string", Required: false, Description: "Domain hint for faster login"},
+			},
+			SupportedScopes: []string{"openid", "email", "profile", "User.Read"},
+			DefaultScopes:   []string{"openid", "email", "profile"},
+			Documentation:   "https://docs.microsoft.com/en-us/azure/active-directory/develop/",
+		},
+		ProviderTypeOIDC: {
+			ProviderType: ProviderTypeOIDC,
+			DisplayName:  "OpenID Connect",
+			Description:  "Generic OpenID Connect authentication provider",
+			ConfigFields: []ProviderConfigField{
+				{Name: "client_id", Type: "string", Required: true, Description: "OIDC Client ID"},
+				{Name: "client_secret", Type: "string", Required: true, Sensitive: true, Description: "OIDC Client Secret"},
+				{Name: "discovery_endpoint", Type: "url", Required: true, Description: "OIDC discovery endpoint"},
+				{Name: "redirect_uri", Type: "url", Required: false, Description: "OAuth2 redirect URI"},
+				{Name: "use_discovery_endpoint", Type: "boolean", Required: false, DefaultValue: true, Description: "Use discovery endpoint"},
+				{Name: "client_authentication", Type: "string", Required: false, DefaultValue: "client_secret_post", Description: "Client authentication method"},
+			},
+			SupportedScopes: []string{"openid", "email", "profile"},
+			DefaultScopes:   []string{"openid", "email", "profile"},
+			Documentation:   "https://openid.net/connect/",
+		},
+		ProviderTypeSAML: {
+			ProviderType: ProviderTypeSAML,
+			DisplayName:  "SAML",
+			Description:  "SAML 2.0 authentication provider",
+			ConfigFields: []ProviderConfigField{
+				{Name: "service_provider_entity_id", Type: "string", Required: true, Description: "Service Provider Entity ID"},
+				{Name: "saml_entity_descriptor", Type: "text", Required: true, Description: "SAML Entity Descriptor XML"},
+				{Name: "sso_service_url", Type: "url", Required: true, Description: "SSO Service URL"},
+				{Name: "identity_provider_entity_id", Type: "string", Required: false, Description: "Identity Provider Entity ID"},
+				{Name: "single_logout_service_url", Type: "url", Required: false, Description: "Single Logout Service URL"},
+				{Name: "nameid_policy_format", Type: "string", Required: false, DefaultValue: "persistent", Description: "NameID Policy Format"},
+				{Name: "want_authn_requests_signed", Type: "boolean", Required: false, DefaultValue: false, Description: "Sign authentication requests"},
+				{Name: "validate_signatures", Type: "boolean", Required: false, DefaultValue: false, Description: "Validate SAML signatures"},
+			},
+			Documentation: "https://docs.oasis-open.org/security/saml/v2.0/",
+		},
+	}
+}
+
+// ValidateConfiguration validates provider configuration based on type
+func (t *IdentityProviderTable) ValidateConfiguration(ctx context.Context, providerType ProviderType, config map[string]interface{}) error {
+	metadata := GetProviderMetadata()
+	providerMeta, exists := metadata[providerType]
+	if !exists {
+		return ErrUnsupportedProviderType
+	}
+
+	// Validate required fields
+	for _, field := range providerMeta.ConfigFields {
+		if field.Required {
+			if _, exists := config[field.Name]; !exists {
+				return &ValidationError{
+					Field:   field.Name,
+					Message: "required field is missing",
+				}
+			}
+		}
+	}
+
+	// Type-specific validation
+	switch providerType {
+	case ProviderTypeUnspecified:
+		return ErrUnsupportedProviderType
+	case ProviderTypeGoogle:
+		return t.validateGoogleConfig(config)
+	case ProviderTypeMicrosoft:
+		return t.validateMicrosoftConfig(config)
+	case ProviderTypeOIDC:
+		return t.validateOIDCConfig(config)
+	case ProviderTypeSAML:
+		return t.validateSAMLConfig(config)
+	}
+
+	return nil
+}
+
+// validateGoogleConfig validates Google OAuth2 configuration
+func (t *IdentityProviderTable) validateGoogleConfig(config map[string]interface{}) error {
+	var googleConfig GoogleOAuth2Config
+	configBytes, _ := json.Marshal(config)
+	if err := json.Unmarshal(configBytes, &googleConfig); err != nil {
+		return &ValidationError{Field: "configuration", Message: "invalid configuration format"}
+	}
+
+	if googleConfig.ClientID == "" {
+		return &ValidationError{Field: "client_id", Message: "client_id is required"}
+	}
+	if googleConfig.ClientSecret == "" {
+		return &ValidationError{Field: "client_secret", Message: "client_secret is required"}
+	}
+
+	// Validate hosted domain format if provided
+	if googleConfig.HostedDomain != "" {
+		if err := validateDomain(googleConfig.HostedDomain); err != nil {
+			return &ValidationError{Field: "hosted_domain", Message: fmt.Sprintf("invalid domain format: %v", err)}
+		}
+	}
+
+	// Validate redirect URI if provided
+	if googleConfig.RedirectURI != "" {
+		if err := validateURL(googleConfig.RedirectURI); err != nil {
+			return &ValidationError{Field: "redirect_uri", Message: fmt.Sprintf("invalid redirect URI: %v", err)}
+		}
+	}
+
+	return nil
+}
+
+// validateMicrosoftConfig validates Microsoft OAuth2 configuration
+func (t *IdentityProviderTable) validateMicrosoftConfig(config map[string]interface{}) error {
+	var msConfig MicrosoftOAuth2Config
+	configBytes, _ := json.Marshal(config)
+	if err := json.Unmarshal(configBytes, &msConfig); err != nil {
+		return &ValidationError{Field: "configuration", Message: "invalid configuration format"}
+	}
+
+	if msConfig.ClientID == "" {
+		return &ValidationError{Field: "client_id", Message: "client_id is required"}
+	}
+	if msConfig.ClientSecret == "" {
+		return &ValidationError{Field: "client_secret", Message: "client_secret is required"}
+	}
+
+	// Validate tenant ID format if provided
+	if msConfig.TenantID != "" && msConfig.TenantID != "common" && msConfig.TenantID != "organizations" && msConfig.TenantID != "consumers" {
+		if err := validateUUID(msConfig.TenantID); err != nil {
+			return &ValidationError{Field: "tenant_id", Message: fmt.Sprintf("invalid tenant_id format: %v", err)}
+		}
+	}
+
+	// Validate redirect URI if provided
+	if msConfig.RedirectURI != "" {
+		if err := validateURL(msConfig.RedirectURI); err != nil {
+			return &ValidationError{Field: "redirect_uri", Message: fmt.Sprintf("invalid redirect URI: %v", err)}
+		}
+	}
+
+	return nil
+}
+
+// validateOIDCConfig validates OIDC configuration
+func (t *IdentityProviderTable) validateOIDCConfig(config map[string]interface{}) error {
+	var oidcConfig OIDCConfig
+	configBytes, _ := json.Marshal(config)
+	if err := json.Unmarshal(configBytes, &oidcConfig); err != nil {
+		return &ValidationError{Field: "configuration", Message: "invalid configuration format"}
+	}
+
+	if oidcConfig.ClientID == "" {
+		return &ValidationError{Field: "client_id", Message: "client_id is required"}
+	}
+	if oidcConfig.ClientSecret == "" {
+		return &ValidationError{Field: "client_secret", Message: "client_secret is required"}
+	}
+	if oidcConfig.DiscoveryEndpoint == "" {
+		return &ValidationError{Field: "discovery_endpoint", Message: "discovery_endpoint is required"}
+	}
+
+	// Validate discovery endpoint URL
+	if err := validateURL(oidcConfig.DiscoveryEndpoint); err != nil {
+		return &ValidationError{Field: "discovery_endpoint", Message: fmt.Sprintf("invalid discovery endpoint URL: %v", err)}
+	}
+
+	// Require HTTPS for discovery endpoint security
+	parsedURL, err := url.Parse(oidcConfig.DiscoveryEndpoint)
+	if err != nil {
+		return &ValidationError{Field: "discovery_endpoint", Message: "invalid discovery endpoint URL format"}
+	}
+	if parsedURL.Scheme != "https" {
+		return &ValidationError{Field: "discovery_endpoint", Message: "discovery endpoint must use https"}
+	}
+
+	// Validate redirect URI if provided
+	if oidcConfig.RedirectURI != "" {
+		if err := validateURL(oidcConfig.RedirectURI); err != nil {
+			return &ValidationError{Field: "redirect_uri", Message: fmt.Sprintf("invalid redirect URI: %v", err)}
+		}
+	}
+
+	// Validate JWKS URL if provided
+	if oidcConfig.JWKSURL != "" {
+		if err := validateURL(oidcConfig.JWKSURL); err != nil {
+			return &ValidationError{Field: "jwks_url", Message: fmt.Sprintf("invalid JWKS URL: %v", err)}
+		}
+	}
+
+	return nil
+}
+
+// validateSAMLConfig validates SAML configuration
+func (t *IdentityProviderTable) validateSAMLConfig(config map[string]interface{}) error {
+	var samlConfig SAMLConfig
+	configBytes, _ := json.Marshal(config)
+	if err := json.Unmarshal(configBytes, &samlConfig); err != nil {
+		return &ValidationError{Field: "configuration", Message: "invalid configuration format"}
+	}
+
+	if samlConfig.ServiceProviderEntityID == "" {
+		return &ValidationError{Field: "service_provider_entity_id", Message: "service_provider_entity_id is required"}
+	}
+	if samlConfig.SAMLEntityDescriptor == "" {
+		return &ValidationError{Field: "saml_entity_descriptor", Message: "saml_entity_descriptor is required"}
+	}
+	if samlConfig.SSOServiceURL == "" {
+		return &ValidationError{Field: "sso_service_url", Message: "sso_service_url is required"}
+	}
+
+	// Validate SSO service URL
+	if err := validateURL(samlConfig.SSOServiceURL); err != nil {
+		return &ValidationError{Field: "sso_service_url", Message: fmt.Sprintf("invalid SSO service URL: %v", err)}
+	}
+
+	// Require HTTPS for SSO service URL security
+	parsedURL, err := url.Parse(samlConfig.SSOServiceURL)
+	if err != nil {
+		return &ValidationError{Field: "sso_service_url", Message: "invalid SSO service URL format"}
+	}
+	if parsedURL.Scheme != "https" {
+		return &ValidationError{Field: "sso_service_url", Message: "SSO service URL must use HTTPS"}
+	}
+
+	// Validate SingleLogoutServiceURL if provided
+	if samlConfig.SingleLogoutServiceURL != "" {
+		if err := validateURL(samlConfig.SingleLogoutServiceURL); err != nil {
+			return &ValidationError{Field: "single_logout_service_url", Message: fmt.Sprintf("invalid single logout service URL: %v", err)}
+		}
+
+		// Require HTTPS for Single Logout Service URL security
+		parsedURL, err := url.Parse(samlConfig.SingleLogoutServiceURL)
+		if err != nil {
+			return &ValidationError{Field: "single_logout_service_url", Message: "invalid single logout service URL format"}
+		}
+		if parsedURL.Scheme != "https" {
+			return &ValidationError{Field: "single_logout_service_url", Message: "single logout service URL must use HTTPS"}
+		}
+	}
+
+	// Validate redirect URI if provided
+	if samlConfig.RedirectURI != "" {
+		if err := validateURL(samlConfig.RedirectURI); err != nil {
+			return &ValidationError{Field: "redirect_uri", Message: fmt.Sprintf("invalid redirect URI: %v", err)}
+		}
+	}
+
+	return nil
+}
+
+// Custom error types
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("validation error for field '%s': %s", e.Field, e.Message)
+}
+
+var (
+	ErrUnsupportedProviderType = fmt.Errorf("unsupported provider type")
+	ErrProviderNotFound        = fmt.Errorf("identity provider not found")
+	ErrDuplicateAlias          = fmt.Errorf("identity provider with this alias already exists")
+)
+
+// Enhanced validation functions that return detailed errors
+func validateDomain(domain string) error {
+	if len(domain) == 0 {
+		return fmt.Errorf("domain cannot be empty")
+	}
+	if len(domain) >= 253 {
+		return fmt.Errorf("domain length cannot exceed 252 characters")
+	}
+	if strings.Contains(domain, " ") {
+		return fmt.Errorf("domain cannot contain spaces")
+	}
+	return nil
+}
+
+func validateUUID(uuidStr string) error {
+	if uuidStr == "" {
+		return fmt.Errorf("UUID cannot be empty")
+	}
+	_, err := uuid.Parse(uuidStr)
+	if err != nil {
+		return fmt.Errorf("invalid UUID format: %w", err)
+	}
+	return nil
+}
+
+func validateURL(urlStr string) error {
+	if urlStr == "" {
+		return fmt.Errorf("URL cannot be empty")
+	}
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil {
+		return fmt.Errorf("invalid URL format: %w", err)
+	}
+	if parsedURL.Scheme == "" {
+		return fmt.Errorf("URL must include a scheme (http:// or https://)")
+	}
+	if parsedURL.Host == "" {
+		return fmt.Errorf("URL must include a host")
+	}
+	return nil
+}


### PR DESCRIPTION
- Complete CRUD operations for Identity Provider instances
- Multi-provider support: Google OAuth2, Microsoft OAuth2

- GET /api/mytenant/v1/identity-provider/providers - List supported provider types
- POST /api/mytenant/v1/identity-provider/instances - Create identity provider instance
- GET /api/mytenant/v1/identity-provider/instances/{alias} - Get provider instance
- PUT /api/mytenant/v1/identity-provider/instances/{alias} - Update provider instance
- DELETE /api/mytenant/v1/identity-provider/instances/{alias} - Delete provider instance