### PR TITLE
Return empty list for list apis for entries not found

### DIFF
--- a/pkg/server/myaccount.go
+++ b/pkg/server/myaccount.go
@@ -379,10 +379,7 @@ func (s *MyAccountServer) ListApiKeys(ctx context.Context, req *api.ApiKeysListR
 		Username: authInfo.UserName,
 	}
 	keys, err := s.apiKeys.FindByUser(ctx, user)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "No API keys found for user %s in tenant %s", user.Username, user.Tenant)
-		}
+	if err != nil && !errors.IsNotFound(err){
 		log.Printf("got error while fetching apikey list (%v): %s", user, err)
 		return nil, status.Errorf(codes.Internal, "Something went wrong, Please try again later")
 	}
@@ -446,10 +443,7 @@ func (s *MyAccountServer) ListMyOrgUnits(ctx context.Context, req *api.MyOrgUnit
 		return resp, nil
 	}
 	OrgUnits, err := s.ouTable.FindByTenant(ctx, authInfo.Realm, "")
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "No Org Unit available for tenant %s", authInfo.Realm)
-		}
+	if err != nil && !errors.IsNotFound(err) {
 		log.Printf("got error while fetching org unit list for tenant %s: %s", authInfo.Realm, err)
 		return nil, status.Errorf(codes.Internal, "Something went wrong, Please try again later")
 	}

--- a/pkg/server/org-unit-user.go
+++ b/pkg/server/org-unit-user.go
@@ -38,7 +38,7 @@ func (s *OrgUnitUserServer) ListOrgUnitUsers(ctx context.Context, req *api.OrgUn
 
 	list, err := s.tbl.GetByOrgUnitId(ctx, req.Ou, req.Offset, req.Limit)
 
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		log.Printf("failed to get list of org unit users, got error: %s", err)
 		return nil, status.Errorf(codes.Internal, "Something went wrong, please try again later")
 	}

--- a/pkg/server/org-unit.go
+++ b/pkg/server/org-unit.go
@@ -32,10 +32,7 @@ func (s *OrgUnitServer) ListOrgUnits(ctx context.Context, req *api.OrgUnitsListR
 		return nil, status.Errorf(codes.Unauthenticated, "User not authenticated")
 	}
 	OrgUnits, err := s.ouTable.FindByTenant(ctx, authInfo.Realm, "")
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "No Org Unit available for tenant %s", authInfo.Realm)
-		}
+	if err != nil && !errors.IsNotFound(err){
 		log.Printf("got error while fetching org unit list for tenant %s: %s", authInfo.Realm, err)
 		return nil, status.Errorf(codes.Internal, "Something went wrong, Please try again later")
 	}

--- a/pkg/server/tenant-user.go
+++ b/pkg/server/tenant-user.go
@@ -433,10 +433,7 @@ func (s *TenantUserApiServer) ListTenantUserOrgUnits(ctx context.Context, req *a
 		Name: req.Tenant,
 	}
 	_, err := s.tenantTbl.Find(ctx, tenantKey)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, status.Errorf(codes.NotFound, "Tenant %s not found", req.Tenant)
-		}
+	if err != nil && !errors.IsNotFound(err){
 		log.Printf("error getting tenant %s: %s", req.Tenant, err)
 		return nil, status.Errorf(codes.Internal, "Something went wrong, Please try again later")
 	}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -59,7 +59,7 @@ func (s *TenantServer) ListTenants(ctx context.Context, req *api.TenantsListReq)
 		return nil, status.Errorf(codes.Internal, "Something went wrong, Please try again later")
 	}
 	list, err := s.tenantTbl.FindMany(ctx, nil, req.Offset, req.Limit)
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err){
 		log.Printf("got error while fetching list of tenants: %s", err)
 		return nil, status.Errorf(codes.Internal, "Something went wrong, Please try again later")
 	}

--- a/pkg/server/user.go
+++ b/pkg/server/user.go
@@ -478,7 +478,7 @@ func (s *UserApiServer) ListUserOrgUnits(ctx context.Context, req *api.UserOrgUn
 
 	// Get org units where the current user has roles
 	orgUnitUsers, err := s.orgUnitUserTbl.GetByUser(ctx, tenant, req.Username)
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err){
 		log.Printf("error getting org units for user %s in tenant %s: %s", req.Username, tenant, err)
 		return nil, status.Errorf(codes.Internal, "Something went wrong, Please try again later")
 	}


### PR DESCRIPTION
- List apis should return an empty list and not throw 404 when no entries are found as part of the list request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * List views now return empty results instead of “Not Found” errors when no data exists (e.g., API keys, tenants, org units, user/org unit mappings).
  * Users will see proper empty states rather than error banners, improving consistency across account and organization pages.
  * Pagination and counts behave correctly for zero-item results.
  * Unexpected failures still return a clear internal error, reducing false alarms and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->