### PR TITLE
Add location enrichment to session APIs

### DIFF
--- a/api/myaccount.pb.go
+++ b/api/myaccount.pb.go
@@ -196,7 +196,9 @@ type MySessionInfo struct {
 	// last access time
 	LastAccess int64 `protobuf:"varint,3,opt,name=lastAccess,proto3" json:"lastAccess,omitempty"`
 	// incoming client ip
-	Ip            string `protobuf:"bytes,4,opt,name=ip,proto3" json:"ip,omitempty"`
+	Ip string `protobuf:"bytes,4,opt,name=ip,proto3" json:"ip,omitempty"`
+	// location information based on IP (optional, omitted for private IPs)
+	Loc           *Location `protobuf:"bytes,5,opt,name=loc,proto3,oneof" json:"loc,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -257,6 +259,13 @@ func (x *MySessionInfo) GetIp() string {
 		return x.Ip
 	}
 	return ""
+}
+
+func (x *MySessionInfo) GetLoc() *Location {
+	if x != nil {
+		return x.Loc
+	}
+	return nil
 }
 
 // my sessions get response
@@ -1553,6 +1562,61 @@ func (x *MyAzsListResp) GetItems() []*MyAzsListEntry {
 	return nil
 }
 
+// location information derived from IP address
+type Location struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// city name
+	City string `protobuf:"bytes,1,opt,name=city,proto3" json:"city,omitempty"`
+	// country name
+	Country       string `protobuf:"bytes,2,opt,name=country,proto3" json:"country,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Location) Reset() {
+	*x = Location{}
+	mi := &file_myaccount_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Location) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Location) ProtoMessage() {}
+
+func (x *Location) ProtoReflect() protoreflect.Message {
+	mi := &file_myaccount_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Location.ProtoReflect.Descriptor instead.
+func (*Location) Descriptor() ([]byte, []int) {
+	return file_myaccount_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *Location) GetCity() string {
+	if x != nil {
+		return x.City
+	}
+	return ""
+}
+
+func (x *Location) GetCountry() string {
+	if x != nil {
+		return x.Country
+	}
+	return ""
+}
+
 var File_myaccount_proto protoreflect.FileDescriptor
 
 const file_myaccount_proto_rawDesc = "" +
@@ -1563,14 +1627,16 @@ const file_myaccount_proto_rawDesc = "" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x1c\n" +
 	"\tfirstName\x18\x02 \x01(\tR\tfirstName\x12\x1a\n" +
 	"\blastName\x18\x03 \x01(\tR\blastName\x12\x14\n" +
-	"\x05email\x18\x04 \x01(\tR\x05email\"w\n" +
+	"\x05email\x18\x04 \x01(\tR\x05email\"\xa5\x01\n" +
 	"\rMySessionInfo\x12\x1c\n" +
 	"\tsessionId\x18\x01 \x01(\tR\tsessionId\x12\x18\n" +
 	"\astarted\x18\x02 \x01(\x03R\astarted\x12\x1e\n" +
 	"\n" +
 	"lastAccess\x18\x03 \x01(\x03R\n" +
 	"lastAccess\x12\x0e\n" +
-	"\x02ip\x18\x04 \x01(\tR\x02ip\"=\n" +
+	"\x02ip\x18\x04 \x01(\tR\x02ip\x12$\n" +
+	"\x03loc\x18\x05 \x01(\v2\r.api.LocationH\x00R\x03loc\x88\x01\x01B\x06\n" +
+	"\x04_loc\"=\n" +
 	"\x11MySessionsGetResp\x12(\n" +
 	"\x05items\x18\x01 \x03(\v2\x12.api.MySessionInfoR\x05items\"3\n" +
 	"\x13MySessionsLogoutReq\x12\x1c\n" +
@@ -1636,7 +1702,10 @@ const file_myaccount_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\":\n" +
 	"\rMyAzsListResp\x12)\n" +
-	"\x05items\x18\x02 \x03(\v2\x13.api.MyAzsListEntryR\x05items2\xe1\t\n" +
+	"\x05items\x18\x02 \x03(\v2\x13.api.MyAzsListEntryR\x05items\"8\n" +
+	"\bLocation\x12\x12\n" +
+	"\x04city\x18\x01 \x01(\tR\x04city\x12\x18\n" +
+	"\acountry\x18\x02 \x01(\tR\acountry2\xe1\t\n" +
 	"\tMyAccount\x12R\n" +
 	"\tGetMyInfo\x12\x11.api.MyInfoGetReq\x1a\x12.api.MyInfoGetResp\"\x1e\x82\xd3\xe4\x93\x02\x18\x12\x16/api/myaccount/v1/info\x12b\n" +
 	"\rGetMySessions\x12\x15.api.MySessionsGetReq\x1a\x16.api.MySessionsGetResp\"\"\x82\xd3\xe4\x93\x02\x1c\x12\x1a/api/myaccount/v1/sessions\x12u\n" +
@@ -1666,7 +1735,7 @@ func file_myaccount_proto_rawDescGZIP() []byte {
 }
 
 var file_myaccount_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_myaccount_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
+var file_myaccount_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_myaccount_proto_goTypes = []any{
 	(ApiKeyDef_Status)(0),        // 0: api.ApiKeyDef.Status
 	(*MyInfoGetReq)(nil),         // 1: api.MyInfoGetReq
@@ -1699,46 +1768,48 @@ var file_myaccount_proto_goTypes = []any{
 	(*MyAzsListReq)(nil),         // 28: api.MyAzsListReq
 	(*MyAzsListEntry)(nil),       // 29: api.MyAzsListEntry
 	(*MyAzsListResp)(nil),        // 30: api.MyAzsListResp
+	(*Location)(nil),             // 31: api.Location
 }
 var file_myaccount_proto_depIdxs = []int32{
-	3,  // 0: api.MySessionsGetResp.items:type_name -> api.MySessionInfo
-	0,  // 1: api.ApiKeyCreateResp.status:type_name -> api.ApiKeyDef.Status
-	0,  // 2: api.ApiKeyListEntry.status:type_name -> api.ApiKeyDef.Status
-	17, // 3: api.ApiKeysListResp.items:type_name -> api.ApiKeyListEntry
-	21, // 4: api.MyOrgUnitsListResp.default:type_name -> api.MyOrgUnitEntry
-	21, // 5: api.MyOrgUnitsListResp.items:type_name -> api.MyOrgUnitEntry
-	26, // 6: api.MyRegionsListResp.default:type_name -> api.MyRegionsListEntry
-	26, // 7: api.MyRegionsListResp.items:type_name -> api.MyRegionsListEntry
-	29, // 8: api.MyAzsListResp.items:type_name -> api.MyAzsListEntry
-	1,  // 9: api.MyAccount.GetMyInfo:input_type -> api.MyInfoGetReq
-	19, // 10: api.MyAccount.GetMySessions:input_type -> api.MySessionsGetReq
-	5,  // 11: api.MyAccount.LogoutMySessions:input_type -> api.MySessionsLogoutReq
-	7,  // 12: api.MyAccount.CreateApiKey:input_type -> api.ApiKeyCreateReq
-	10, // 13: api.MyAccount.DisableApiKey:input_type -> api.ApiKeyDisableReq
-	12, // 14: api.MyAccount.EnableApiKey:input_type -> api.ApiKeyEnableReq
-	14, // 15: api.MyAccount.DeleteApiKey:input_type -> api.ApiKeyDeleteReq
-	16, // 16: api.MyAccount.ListApiKeys:input_type -> api.ApiKeysListReq
-	20, // 17: api.MyAccount.ListMyOrgUnits:input_type -> api.MyOrgUnitsListReq
-	23, // 18: api.MyAccount.SetDefaultOrgUnit:input_type -> api.DefaultOrgUnitReq
-	25, // 19: api.MyAccount.ListMyRegions:input_type -> api.MyRegionsListReq
-	28, // 20: api.MyAccount.ListMyAzs:input_type -> api.MyAzsListReq
-	2,  // 21: api.MyAccount.GetMyInfo:output_type -> api.MyInfoGetResp
-	4,  // 22: api.MyAccount.GetMySessions:output_type -> api.MySessionsGetResp
-	6,  // 23: api.MyAccount.LogoutMySessions:output_type -> api.MySessionsLogoutResp
-	9,  // 24: api.MyAccount.CreateApiKey:output_type -> api.ApiKeyCreateResp
-	11, // 25: api.MyAccount.DisableApiKey:output_type -> api.ApiKeyDisableResp
-	13, // 26: api.MyAccount.EnableApiKey:output_type -> api.ApiKeyEnableResp
-	15, // 27: api.MyAccount.DeleteApiKey:output_type -> api.ApiKeyDeleteResp
-	18, // 28: api.MyAccount.ListApiKeys:output_type -> api.ApiKeysListResp
-	22, // 29: api.MyAccount.ListMyOrgUnits:output_type -> api.MyOrgUnitsListResp
-	24, // 30: api.MyAccount.SetDefaultOrgUnit:output_type -> api.DefaultOrgUnitResp
-	27, // 31: api.MyAccount.ListMyRegions:output_type -> api.MyRegionsListResp
-	30, // 32: api.MyAccount.ListMyAzs:output_type -> api.MyAzsListResp
-	21, // [21:33] is the sub-list for method output_type
-	9,  // [9:21] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	31, // 0: api.MySessionInfo.loc:type_name -> api.Location
+	3,  // 1: api.MySessionsGetResp.items:type_name -> api.MySessionInfo
+	0,  // 2: api.ApiKeyCreateResp.status:type_name -> api.ApiKeyDef.Status
+	0,  // 3: api.ApiKeyListEntry.status:type_name -> api.ApiKeyDef.Status
+	17, // 4: api.ApiKeysListResp.items:type_name -> api.ApiKeyListEntry
+	21, // 5: api.MyOrgUnitsListResp.default:type_name -> api.MyOrgUnitEntry
+	21, // 6: api.MyOrgUnitsListResp.items:type_name -> api.MyOrgUnitEntry
+	26, // 7: api.MyRegionsListResp.default:type_name -> api.MyRegionsListEntry
+	26, // 8: api.MyRegionsListResp.items:type_name -> api.MyRegionsListEntry
+	29, // 9: api.MyAzsListResp.items:type_name -> api.MyAzsListEntry
+	1,  // 10: api.MyAccount.GetMyInfo:input_type -> api.MyInfoGetReq
+	19, // 11: api.MyAccount.GetMySessions:input_type -> api.MySessionsGetReq
+	5,  // 12: api.MyAccount.LogoutMySessions:input_type -> api.MySessionsLogoutReq
+	7,  // 13: api.MyAccount.CreateApiKey:input_type -> api.ApiKeyCreateReq
+	10, // 14: api.MyAccount.DisableApiKey:input_type -> api.ApiKeyDisableReq
+	12, // 15: api.MyAccount.EnableApiKey:input_type -> api.ApiKeyEnableReq
+	14, // 16: api.MyAccount.DeleteApiKey:input_type -> api.ApiKeyDeleteReq
+	16, // 17: api.MyAccount.ListApiKeys:input_type -> api.ApiKeysListReq
+	20, // 18: api.MyAccount.ListMyOrgUnits:input_type -> api.MyOrgUnitsListReq
+	23, // 19: api.MyAccount.SetDefaultOrgUnit:input_type -> api.DefaultOrgUnitReq
+	25, // 20: api.MyAccount.ListMyRegions:input_type -> api.MyRegionsListReq
+	28, // 21: api.MyAccount.ListMyAzs:input_type -> api.MyAzsListReq
+	2,  // 22: api.MyAccount.GetMyInfo:output_type -> api.MyInfoGetResp
+	4,  // 23: api.MyAccount.GetMySessions:output_type -> api.MySessionsGetResp
+	6,  // 24: api.MyAccount.LogoutMySessions:output_type -> api.MySessionsLogoutResp
+	9,  // 25: api.MyAccount.CreateApiKey:output_type -> api.ApiKeyCreateResp
+	11, // 26: api.MyAccount.DisableApiKey:output_type -> api.ApiKeyDisableResp
+	13, // 27: api.MyAccount.EnableApiKey:output_type -> api.ApiKeyEnableResp
+	15, // 28: api.MyAccount.DeleteApiKey:output_type -> api.ApiKeyDeleteResp
+	18, // 29: api.MyAccount.ListApiKeys:output_type -> api.ApiKeysListResp
+	22, // 30: api.MyAccount.ListMyOrgUnits:output_type -> api.MyOrgUnitsListResp
+	24, // 31: api.MyAccount.SetDefaultOrgUnit:output_type -> api.DefaultOrgUnitResp
+	27, // 32: api.MyAccount.ListMyRegions:output_type -> api.MyRegionsListResp
+	30, // 33: api.MyAccount.ListMyAzs:output_type -> api.MyAzsListResp
+	22, // [22:34] is the sub-list for method output_type
+	10, // [10:22] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_myaccount_proto_init() }
@@ -1746,13 +1817,14 @@ func file_myaccount_proto_init() {
 	if File_myaccount_proto != nil {
 		return
 	}
+	file_myaccount_proto_msgTypes[2].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_myaccount_proto_rawDesc), len(file_myaccount_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   30,
+			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/myaccount.proto
+++ b/api/myaccount.proto
@@ -143,6 +143,9 @@ message MySessionInfo {
 
   // incoming client ip
   string ip = 4;
+
+  // location information based on IP (optional, omitted for private IPs)
+  optional Location loc = 5;
 }
 
 // my sessions get response
@@ -338,4 +341,13 @@ message MyAzsListResp {
   // list of available azs for the tenant
   // under a region
   repeated MyAzsListEntry items = 2;
+}
+
+// location information derived from IP address
+message Location {
+  // city name
+  string city = 1;
+  
+  // country name
+  string country = 2;
 }

--- a/api/swagger/apidocs.swagger.json
+++ b/api/swagger/apidocs.swagger.json
@@ -2604,6 +2604,20 @@
         }
       }
     },
+    "apiLocation": {
+      "type": "object",
+      "properties": {
+        "city": {
+          "type": "string",
+          "title": "city name"
+        },
+        "country": {
+          "type": "string",
+          "title": "country name"
+        }
+      },
+      "title": "location information derived from IP address"
+    },
     "apiMicrosoftIDPConfig": {
       "type": "object",
       "properties": {
@@ -2985,6 +2999,10 @@
         "ip": {
           "type": "string",
           "title": "incoming client ip"
+        },
+        "loc": {
+          "$ref": "#/definitions/apiLocation",
+          "title": "location information based on IP (optional, omitted for private IPs)"
         }
       },
       "title": "my session information"
@@ -3851,6 +3869,10 @@
         "ip": {
           "type": "string",
           "title": "incoming client ip"
+        },
+        "loc": {
+          "$ref": "#/definitions/apiLocation",
+          "title": "location information based on IP (optional, omitted for private IPs)"
         }
       },
       "title": "user session information"

--- a/api/user.pb.go
+++ b/api/user.pb.go
@@ -1053,7 +1053,9 @@ type UserSessionInfo struct {
 	// last access time
 	LastAccess int64 `protobuf:"varint,4,opt,name=lastAccess,proto3" json:"lastAccess,omitempty"`
 	// incoming client ip
-	Ip            string `protobuf:"bytes,5,opt,name=ip,proto3" json:"ip,omitempty"`
+	Ip string `protobuf:"bytes,5,opt,name=ip,proto3" json:"ip,omitempty"`
+	// location information based on IP (optional, omitted for private IPs)
+	Loc           *Location `protobuf:"bytes,6,opt,name=loc,proto3,oneof" json:"loc,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1121,6 +1123,13 @@ func (x *UserSessionInfo) GetIp() string {
 		return x.Ip
 	}
 	return ""
+}
+
+func (x *UserSessionInfo) GetLoc() *Location {
+	if x != nil {
+		return x.Loc
+	}
+	return nil
 }
 
 // response of list active sessions
@@ -1459,7 +1468,7 @@ var File_user_proto protoreflect.FileDescriptor
 const file_user_proto_rawDesc = "" +
 	"\n" +
 	"\n" +
-	"user.proto\x12\x03api\x1a\x1cgoogle/api/annotations.proto\x1a\x17coreapis/api/role.proto\"T\n" +
+	"user.proto\x12\x03api\x1a\x1cgoogle/api/annotations.proto\x1a\x17coreapis/api/role.proto\x1a\x0fmyaccount.proto\"T\n" +
 	"\fUsersListReq\x12\x16\n" +
 	"\x06offset\x18\x01 \x01(\x05R\x06offset\x12\x14\n" +
 	"\x05limit\x18\x02 \x01(\x05R\x05limit\x12\x16\n" +
@@ -1527,7 +1536,7 @@ const file_user_proto_rawDesc = "" +
 	"\x13UserSessionsListReq\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x16\n" +
 	"\x06offset\x18\x02 \x01(\x05R\x06offset\x12\x14\n" +
-	"\x05limit\x18\x03 \x01(\x05R\x05limit\"\x95\x01\n" +
+	"\x05limit\x18\x03 \x01(\x05R\x05limit\"\xc3\x01\n" +
 	"\x0fUserSessionInfo\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x1c\n" +
 	"\tsessionId\x18\x02 \x01(\tR\tsessionId\x12\x18\n" +
@@ -1535,7 +1544,9 @@ const file_user_proto_rawDesc = "" +
 	"\n" +
 	"lastAccess\x18\x04 \x01(\x03R\n" +
 	"lastAccess\x12\x0e\n" +
-	"\x02ip\x18\x05 \x01(\tR\x02ip\"X\n" +
+	"\x02ip\x18\x05 \x01(\tR\x02ip\x12$\n" +
+	"\x03loc\x18\x06 \x01(\v2\r.api.LocationH\x00R\x03loc\x88\x01\x01B\x06\n" +
+	"\x04_loc\"X\n" +
 	"\x14UserSessionsListResp\x12\x14\n" +
 	"\x05count\x18\x01 \x01(\x05R\x05count\x12*\n" +
 	"\x05items\x18\x02 \x03(\v2\x14.api.UserSessionInfoR\x05items\"P\n" +
@@ -1617,36 +1628,38 @@ var file_user_proto_goTypes = []any{
 	(*UserOrgUnitsListReq)(nil),   // 20: api.UserOrgUnitsListReq
 	(*UserOrgUnitWithRole)(nil),   // 21: api.UserOrgUnitWithRole
 	(*UserOrgUnitsListResp)(nil),  // 22: api.UserOrgUnitsListResp
+	(*Location)(nil),              // 23: api.Location
 }
 var file_user_proto_depIdxs = []int32{
 	1,  // 0: api.UsersListResp.items:type_name -> api.UserListEntry
-	16, // 1: api.UserSessionsListResp.items:type_name -> api.UserSessionInfo
-	21, // 2: api.UserOrgUnitsListResp.items:type_name -> api.UserOrgUnitWithRole
-	0,  // 3: api.User.GetUsers:input_type -> api.UsersListReq
-	3,  // 4: api.User.CreateUser:input_type -> api.UserCreateReq
-	7,  // 5: api.User.GetUser:input_type -> api.UserGetReq
-	11, // 6: api.User.EnableUser:input_type -> api.UserEnableReq
-	13, // 7: api.User.DisableUser:input_type -> api.UserDisableReq
-	9,  // 8: api.User.UpdateUser:input_type -> api.UserUpdateReq
-	5,  // 9: api.User.DeleteUser:input_type -> api.UserDeleteReq
-	15, // 10: api.User.ListUserSessions:input_type -> api.UserSessionsListReq
-	18, // 11: api.User.LogoutUserSession:input_type -> api.UserSessionLogoutReq
-	20, // 12: api.User.ListUserOrgUnits:input_type -> api.UserOrgUnitsListReq
-	2,  // 13: api.User.GetUsers:output_type -> api.UsersListResp
-	4,  // 14: api.User.CreateUser:output_type -> api.UserCreateResp
-	8,  // 15: api.User.GetUser:output_type -> api.UserGetResp
-	12, // 16: api.User.EnableUser:output_type -> api.UserEnableResp
-	14, // 17: api.User.DisableUser:output_type -> api.UserDisableResp
-	10, // 18: api.User.UpdateUser:output_type -> api.UserUpdateResp
-	6,  // 19: api.User.DeleteUser:output_type -> api.UserDeleteResp
-	17, // 20: api.User.ListUserSessions:output_type -> api.UserSessionsListResp
-	19, // 21: api.User.LogoutUserSession:output_type -> api.UserSessionLogoutResp
-	22, // 22: api.User.ListUserOrgUnits:output_type -> api.UserOrgUnitsListResp
-	13, // [13:23] is the sub-list for method output_type
-	3,  // [3:13] is the sub-list for method input_type
-	3,  // [3:3] is the sub-list for extension type_name
-	3,  // [3:3] is the sub-list for extension extendee
-	0,  // [0:3] is the sub-list for field type_name
+	23, // 1: api.UserSessionInfo.loc:type_name -> api.Location
+	16, // 2: api.UserSessionsListResp.items:type_name -> api.UserSessionInfo
+	21, // 3: api.UserOrgUnitsListResp.items:type_name -> api.UserOrgUnitWithRole
+	0,  // 4: api.User.GetUsers:input_type -> api.UsersListReq
+	3,  // 5: api.User.CreateUser:input_type -> api.UserCreateReq
+	7,  // 6: api.User.GetUser:input_type -> api.UserGetReq
+	11, // 7: api.User.EnableUser:input_type -> api.UserEnableReq
+	13, // 8: api.User.DisableUser:input_type -> api.UserDisableReq
+	9,  // 9: api.User.UpdateUser:input_type -> api.UserUpdateReq
+	5,  // 10: api.User.DeleteUser:input_type -> api.UserDeleteReq
+	15, // 11: api.User.ListUserSessions:input_type -> api.UserSessionsListReq
+	18, // 12: api.User.LogoutUserSession:input_type -> api.UserSessionLogoutReq
+	20, // 13: api.User.ListUserOrgUnits:input_type -> api.UserOrgUnitsListReq
+	2,  // 14: api.User.GetUsers:output_type -> api.UsersListResp
+	4,  // 15: api.User.CreateUser:output_type -> api.UserCreateResp
+	8,  // 16: api.User.GetUser:output_type -> api.UserGetResp
+	12, // 17: api.User.EnableUser:output_type -> api.UserEnableResp
+	14, // 18: api.User.DisableUser:output_type -> api.UserDisableResp
+	10, // 19: api.User.UpdateUser:output_type -> api.UserUpdateResp
+	6,  // 20: api.User.DeleteUser:output_type -> api.UserDeleteResp
+	17, // 21: api.User.ListUserSessions:output_type -> api.UserSessionsListResp
+	19, // 22: api.User.LogoutUserSession:output_type -> api.UserSessionLogoutResp
+	22, // 23: api.User.ListUserOrgUnits:output_type -> api.UserOrgUnitsListResp
+	14, // [14:24] is the sub-list for method output_type
+	4,  // [4:14] is the sub-list for method input_type
+	4,  // [4:4] is the sub-list for extension type_name
+	4,  // [4:4] is the sub-list for extension extendee
+	0,  // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_user_proto_init() }
@@ -1654,6 +1667,8 @@ func file_user_proto_init() {
 	if File_user_proto != nil {
 		return
 	}
+	file_myaccount_proto_init()
+	file_user_proto_msgTypes[16].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/api/user.proto
+++ b/api/user.proto
@@ -7,6 +7,7 @@ package api;
 
 import "google/api/annotations.proto";
 import "coreapis/api/role.proto";
+import "myaccount.proto";
 
 option go_package = "github.com/go-core-stack/auth-gateway/api";
 
@@ -333,6 +334,9 @@ message UserSessionInfo {
 
   // incoming client ip
   string ip = 5;
+
+  // location information based on IP (optional, omitted for private IPs)
+  optional Location loc = 6;
 }
 
 // response of list active sessions

--- a/default.yaml
+++ b/default.yaml
@@ -2,3 +2,6 @@ configDB:
   uri: "mongodb://localhost:27017"
 swagger:
   dir: ""
+locationService:
+  host: "location-services"
+  port: "8080"

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-core-stack/auth v0.0.0-20250703132332-24ef7e70de0e
 	github.com/go-core-stack/core v0.0.0-20250808174703-793334d9127e
 	github.com/go-core-stack/grpc-core v0.0.0-20250612052530-de9a8693884f
+	github.com/go-core-stack/location-services v0.0.1
 	github.com/go-core-stack/patricia v0.0.0-20250613164405-ac1bcd231c34
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/go-core-stack/core v0.0.0-20250808174703-793334d9127e h1:nDSguxy/geZd
 github.com/go-core-stack/core v0.0.0-20250808174703-793334d9127e/go.mod h1:twakoIk0zC6ChVRe0l6LOEb+yJPMPBmEnEZSvZY5C8c=
 github.com/go-core-stack/grpc-core v0.0.0-20250612052530-de9a8693884f h1:Vz2mS05ZNfKO3LO4QnYW6tjodSOBh0ViyWrLosSSzkE=
 github.com/go-core-stack/grpc-core v0.0.0-20250612052530-de9a8693884f/go.mod h1:0E4zg2joop2hsTT7XlcY9NtNHDIbbNeE0lQm3jvN488=
+github.com/go-core-stack/location-services v0.0.1 h1:9xMpUDbHwlga9RPVHYuzVvQBN3CVuhX7SzC6oSqPnRs=
+github.com/go-core-stack/location-services v0.0.1/go.mod h1:gXRumRuDgdaBaOnyfFWsWuG0XNebjZqmqBvY3yBhNFY=
 github.com/go-core-stack/patricia v0.0.0-20250613164405-ac1bcd231c34 h1:MRyqhm038Q9yeHrJ9fkbWeoT1b0u9b7bdQk754N9QLA=
 github.com/go-core-stack/patricia v0.0.0-20250613164405-ac1bcd231c34/go.mod h1:bZvyBLDqui1L1wFJCuaZy9BHG4r9Rx3/dVcfxukPwrM=
 github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,16 +22,22 @@ type Keycloak struct {
 	Endpoint string `yaml:"endpoint,omitempty"`
 }
 
+type LocationService struct {
+	Host string `yaml:"host,omitempty"`
+	Port string `yaml:"port,omitempty"`
+}
+
 type CorsConfig struct {
 	Enabled bool `yaml:"enabled,omitempty"`
 }
 
 // Base config struct
 type BaseConfig struct {
-	ConfigDB *MongoDB   `yaml:"configDB,omitempty"`
-	Swagger  Swagger    `yaml:"swagger,omitempty"`
-	Keycloak *Keycloak  `yaml:"keycloak,omitempty"`
-	Cors     CorsConfig `yaml:"cors,omitempty"`
+	ConfigDB        *MongoDB         `yaml:"configDB,omitempty"`
+	Swagger         Swagger          `yaml:"swagger,omitempty"`
+	Keycloak        *Keycloak        `yaml:"keycloak,omitempty"`
+	LocationService *LocationService `yaml:"locationService,omitempty"`
+	Cors            CorsConfig       `yaml:"cors,omitempty"`
 }
 
 // get Config database information, if the struct
@@ -70,6 +76,30 @@ func (c *BaseConfig) GetSwaggerDir() string {
 
 func (c *BaseConfig) IsCORSEnabled() bool {
 	return c.Cors.Enabled
+}
+
+// IsLocationServiceConfigured checks if location service is properly configured
+// with both host and port values
+func (c *BaseConfig) IsLocationServiceConfigured() bool {
+	return c.LocationService != nil &&
+		c.LocationService.Host != "" &&
+		c.LocationService.Port != ""
+}
+
+// GetLocationServiceHost returns the configured location service host
+func (c *BaseConfig) GetLocationServiceHost() string {
+	if c.LocationService != nil {
+		return c.LocationService.Host
+	}
+	return ""
+}
+
+// GetLocationServicePort returns the configured location service port
+func (c *BaseConfig) GetLocationServicePort() string {
+	if c.LocationService != nil {
+		return c.LocationService.Port
+	}
+	return ""
 }
 
 // Parse YAML Config file from the provided config file path


### PR DESCRIPTION
Integrate location-services to provide geographic context for user sessions by enriching session responses with city and country information derived from client IP addresses.

Changes include:
- Add Location message to MySessionInfo and UserSessionInfo protos
- Integrate location-services gRPC client in auth-gateway
- Update server constructors to accept location client parameter

The location enrichment is optional and will be omitted for private IP addresses or when the location service is unreachable. This provides valuable geographic context for session monitoring and security analysis without impacting core authentication flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Session details now show approximate location (city and country) derived from a session’s public IP in My Account and User session views when available; private IPs omit location.
  - Location enrichment is optional and non-blocking with a short timeout to keep session pages responsive.

- **Documentation**
  - API schemas updated to include an optional location object in session-related responses.

- **Chores**
  - New configuration options to enable/point at an external location service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->