### PR TITLE
Handle cleaning up of org unit user

### DIFF
--- a/pkg/table/org-unit-user.go
+++ b/pkg/table/org-unit-user.go
@@ -54,6 +54,16 @@ func (t *OrgUnitUserTable) GetByUser(ctx context.Context, tenant, user string) (
 	return list, nil
 }
 
+func (t *OrgUnitUserTable) DeleteByUser(ctx context.Context, tenant, user string) error {
+	filter := bson.M{
+		"key.tenant":   tenant,
+		"key.username": user,
+	}
+
+	_, err := t.col.DeleteMany(ctx, filter)
+	return err
+}
+
 func (t *OrgUnitUserTable) GetByOrgUnitId(ctx context.Context, orgUnitId string, offset, limit int32) ([]*OrgUnitUser, error) {
 	filter := bson.M{
 		"key.orgUnitId": orgUnitId,


### PR DESCRIPTION
While deleting user ensure cleanup of corresponding org unit users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Deleting a user now also removes their organization unit associations, preventing stale or orphaned records.
  - Improved reliability of user cleanup with better error handling and automatic retries on transient issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->